### PR TITLE
(#9048) Update tests to expand path

### DIFF
--- a/spec/unit/puppet/cloudpack/installer_spec.rb
+++ b/spec/unit/puppet/cloudpack/installer_spec.rb
@@ -29,7 +29,7 @@ describe installer_klass do
       installer_klass.find_template(template_id).should == template_location
     end
     it 'should be able to use a lib version' do
-      installer_klass.find_template('puppet-enterprise').should == File.join(scripts_dir, 'puppet-enterprise.erb')
+      File.expand_path(installer_klass.find_template('puppet-enterprise')).should == File.join(scripts_dir, 'puppet-enterprise.erb')
     end
     it 'should fail when it cannot find a script' do
       now = Time.now.to_i


### PR DESCRIPTION
Updating a spec test to use expand_path
to increase test reliability.

The test was failing on Jenkins b/c it
returns a relative path instead of an
expanded path.
