### PR TITLE
(#8184) update spec test to work with Fog v0.11.0

### DIFF
--- a/spec/unit/puppet/face/node/create_spec.rb
+++ b/spec/unit/puppet/face/node/create_spec.rb
@@ -3,7 +3,7 @@ require 'puppet/cloudpack'
 
 describe Puppet::Face[:node, :current] do
   before :all do
-    data = Fog::AWS::Compute::Mock.data['us-east-1'][Fog.credentials[:aws_access_key_id]]
+    data = Fog::Compute::AWS::Mock.data['us-east-1'][Fog.credentials[:aws_access_key_id]]
     data[:images]['ami-12345'] = { 'imageId' => 'ami-12345' }
     data[:key_pairs]['some_keypair'] = { 'keyName' => 'some_keypair' }
   end
@@ -93,7 +93,7 @@ describe Puppet::Face[:node, :current] do
 
       it 'should validate the region' do
         @options[:region] = 'mars-east-100'
-        expect { subject.create(@options) }.to raise_error ArgumentError, /one of/
+        expect { subject.create(@options) }.to raise_error ArgumentError, /Unknown region/
       end
     end
   end

--- a/spec/unit/puppet/face/node/fingerprint_spec.rb
+++ b/spec/unit/puppet/face/node/fingerprint_spec.rb
@@ -3,7 +3,7 @@ require 'puppet/cloudpack'
 
 describe Puppet::Face[:node, :current] do
   before :all do
-    data = Fog::AWS::Compute::Mock.data['us-east-1'][Fog.credentials[:aws_access_key_id]]
+    data = Fog::Compute::AWS::Mock.data['us-east-1'][Fog.credentials[:aws_access_key_id]]
     data[:images]['ami-12345'] = { 'imageId' => 'ami-12345' }
     data[:key_pairs]['some_keypair'] = { 'keyName' => 'some_keypair' }
   end

--- a/spec/unit/puppet/face/node/list_spec.rb
+++ b/spec/unit/puppet/face/node/list_spec.rb
@@ -3,7 +3,7 @@ require 'puppet/cloudpack'
 
 describe Puppet::Face[:node, :current] do
   before :all do
-    data = Fog::AWS::Compute::Mock.data['us-east-1'][Fog.credentials[:aws_access_key_id]]
+    data = Fog::Compute::AWS::Mock.data['us-east-1'][Fog.credentials[:aws_access_key_id]]
     data[:images]['ami-12345'] = { 'imageId' => 'ami-12345' }
     data[:key_pairs]['some_keypair'] = { 'keyName' => 'some_keypair' }
   end
@@ -48,7 +48,7 @@ describe Puppet::Face[:node, :current] do
 
       it 'should validate the region' do
         @options[:region] = 'mars-east-100'
-        expect { subject.list(@options) }.to raise_error ArgumentError, /one of/
+        expect { subject.list(@options) }.to raise_error ArgumentError, /Unknown region/
       end
     end
 

--- a/spec/unit/puppet/face/node/terminate_spec.rb
+++ b/spec/unit/puppet/face/node/terminate_spec.rb
@@ -41,7 +41,7 @@ describe Puppet::Face[:node, :current] do
 
       it 'should validate the region' do
         @options[:region] = 'mars-east-100'
-        expect { subject.terminate('server', @options) }.to raise_error ArgumentError, /one of/
+        expect { subject.terminate('server', @options) }.to raise_error ArgumentError, /Unknown region/
       end
     end
   end


### PR DESCRIPTION
The spec tests needed to be updated b/c of the following
changes from Fog 0.7.2 to 0.11.0.

Fog::AWS::Compute namespace changed to Fog::Compute::AWS

Invalid ec2 regions are now detected by Fog and a different
exception is being raised.
