### PR TITLE
(#9510) Increase timeout wrapped around ssh

### DIFF
--- a/lib/puppet/cloudpack.rb
+++ b/lib/puppet/cloudpack.rb
@@ -575,7 +575,7 @@ module Puppet::CloudPack
       # We should only really block for 3 minutes or so.
       retries = 0
       begin
-        status = Timeout::timeout(10) do
+        status = Timeout::timeout(25) do
           ssh_remote_execute(server, login, "date", keyfile)
         end
       rescue Net::SSH::AuthenticationFailed, Errno::ECONNREFUSED => e


### PR DESCRIPTION
Increases the timeout wrapped around ssh execution
from 10 to 25 seconds.

10 seconds was a little unreliable, and frequently resulted
in unwarrented timeouts.
