### PR TITLE
(#9426) Add acceptance tests

### DIFF
--- a/acceptance_tests/config/2rhel.cfg
+++ b/acceptance_tests/config/2rhel.cfg
@@ -1,0 +1,13 @@
+#
+# Example file that can be used
+# to perform testing on rhel 5 machines
+HOSTS:
+  rhel-55-64-1:
+    roles:
+      - controller
+      - agent
+    platform: el-5-x86_64
+CONFIG:
+  filecount: 12
+  nfs_server: 192.168.97.1
+  pe_nfs_mount: /mnt/ro/pe

--- a/acceptance_tests/install.rb
+++ b/acceptance_tests/install.rb
@@ -1,0 +1,57 @@
+#
+# This uses the test harness to install
+# and configure cloud provisioner
+#
+# This can be removed once the installation
+# of cloud provisioner is added to PE
+#
+# on every node, we need to install the fog gem
+controller = nil
+test_name "Install Puppet Cloud Provisioner"
+# find the controller node
+hosts.each do |host|
+  if host['roles'].include? 'controller'
+    controller = host
+  end
+end
+
+skip_test 'test requires a master and controller' unless controller and master
+
+step 'give the controller access to sign certs on the master'
+
+cert_auth ="
+path /certificate_status
+method save
+auth yes
+allow #{controller.to_s}
+"
+
+# copy auth rules to the top of the file
+auth_path='/etc/puppetlabs/puppet/auth.conf'
+
+on master, "mv #{auth_path}{,.save}"
+on master, "echo '#{cert_auth}' > #{auth_path};cat #{auth_path}.save >> #{auth_path}"
+
+skip_test 'cannot find fog credentials' unless File.exists?(File.expand_path '~/.fog')
+
+# install the latest version of fog, this should use the source version
+# the vspere support will require master
+step 'install latest version of fog'
+on controller, 'yum install -y libxml2 libxml2-devel libxslt libxslt-devel'
+on controller, '/opt/puppet/bin/gem install guid --no-rdoc --no-ri'
+# the latest version of net-ssh causes fog to fail to install
+on controller, '/opt/puppet/bin/gem install net-ssh -v 2.1.4 --no-ri --no-rdoc'
+on controller, '/opt/puppet/bin/gem install fog --no-ri --no-rdoc'
+on controller, 'cd /opt/puppet;git clone http://github.com/puppetlabs/puppetlabs-cloud-provisioner.git'
+# assumes that you have bash installed
+on controller, 'echo "export RUBYLIB=/opt/puppet/puppetlabs-cloud-provisioner/lib/:$RUBYLIB" >> /root/.bashrc'
+
+step 'provide test machine ec2 credentials. Be warned, your credientials located at ~/.fog are being copied to the test machine at /root/.fog.'
+
+scp_to controller, File.expand_path('~/.fog'), '/root/.fog'
+
+step 'test that fog can connect to ec2 with provided credentials'
+# this is failing b/c of net/ssh mismatch?
+# sync clocks so that the EC2 connection will work
+on controller, 'ntpdate pool.ntp.org'
+on controller, '/opt/puppet/bin/ruby -rubygems -e \'require "fog"\' -e \'puts Fog::Compute.new(:provider => "AWS").servers.length >= 0\''

--- a/acceptance_tests/tests/create_ec2_instance.rb
+++ b/acceptance_tests/tests/create_ec2_instance.rb
@@ -1,0 +1,102 @@
+# variables that need to be set at a higher level
+ami='ami-06ad526f'
+login='ubuntu'
+keypair=@options[:keypair]
+keyfile=@options[:keyfile]
+
+# this method can be used to parse out the nodes
+# that are described in STDOUT from the list
+# action
+def parse_node_list(stdout)
+  node_status = {}
+  entries = stdout.split("\ni")
+  entries.each do |entry|
+    status = {}
+    # the first i did not get split out
+    unless entry =~ /^i/
+      entry='i'+entry
+    end
+    status_lines = entry.split("\n")
+    # git rid of the first line
+    # I don't care about the ids
+    status_lines.shift
+    status_lines.each do |status_line|
+      status_line.gsub!(/^  /, '')
+      attr = status_line.split(': ')
+      if attr.size == 2
+        status[attr[0]] = attr[1]
+      end
+    end
+    # hash all of the properties by the dns_name of the node
+    # I only care about entries that have a listed dnsname
+    # the dns_names are deallocated when the machine shuts
+    # down
+    if status['dns_name']
+      node_status[status['dns_name']] = status
+    end
+  end
+  node_status
+end
+
+controller = nil
+test_name "Test Puppet Cloud Provisioner: create, install, list and destroy"
+
+# find the controller node
+hosts.each do |host|
+  if host['roles'].include? 'controller'
+    controller = host
+  end
+end
+
+step 'test that we can create ec2 instance(s)'
+
+agent_dnsname=nil
+on controller, "puppet node_aws create -i #{ami} --keypair #{keypair} --type t1.micro" do
+  # set the dnsname as the last line returned
+  agent_dnsname=stdout.split("\n").last
+end
+
+step "test that we can list the created instances: #{agent_dnsname}"
+
+nodes_info=nil
+on controller, 'puppet node_aws list' do
+  nodes_info=parse_node_list(stdout)
+  assert_equal('running', nodes_info[agent_dnsname]['state'], "Failed to launch an agent EC2 instance")
+end
+
+# copy the ec2 private key to the controller
+# I would rather use ssh forwarding if I can
+scp_to controller, File.expand_path(keyfile), "/root/.ssh/#{File.basename(keyfile)}"
+
+step "test that we can install PE agent on #{agent_dnsname}"
+agent_certname=nil
+# I would like to be able to see stdout/err even when it fails?
+on controller, "puppet node install --keyfile /root/.ssh/#{File.basename(keyfile)} --login #{login} --install-script=gems --server #{master} --debug --verbose --trace #{agent_dnsname}", :acceptable_exit_codes => [ 0 ] do
+  agent_certname = stdout.split("\n").last.chomp
+end
+
+on controller, "puppet certificate sign #{agent_certname} --ca-location remote --mode agent" do
+end
+
+step "test that we can destroy the created instances: #{agent_dnsname}"
+
+on controller, "puppet node_aws terminate #{agent_dnsname}" do
+  last_line = stdout.split("\n").last
+  assert_match(/Destroying #{nodes_info[agent_dnsname]['id']} \(#{agent_dnsname}\) ... Done/, last_line, 'Failed to destroy instance')
+end
+
+# instead of puppet node list, maybe I should use fog to double check?
+on controller, 'puppet node_aws list' do
+  nodes_list = parse_node_list(stdout)
+  if my_node = nodes_list[agent_dnsname]
+    assert(my_node['state'] == 'shutting-down' || my_node['state'] == 'terminated', "Node: #{agent_dnsname} was not shut down")
+  end
+  # I would like to fail if there are any extra instances?
+  # but I cant if I share the key
+  nodes_list.each do |name, my_node|
+    unless my_node['state'] == 'shutting-down' || my_node['state'] == 'terminated'
+      puts "Warning: node #{name} is not shut down"
+    end
+    # fail if any instances are running
+  end
+end


### PR DESCRIPTION
This patch adds acceptance tests for cloud provisioner.

This includes: example test config file, script to install
cloud provisioner for testing, and the actual test script.

The following things are tested by this patch:
  puppet node_aws create - creates a new machine instance
  puppet node_aws list - can list the new instance
  puppet node install - can install puppet on the instance
  puppet certificate sign - can sign the nodes certificates
  puppet node_aws terminate - can terminate the node
  puppet node_aws list - can no longer see the node
