### PR TITLE
Remove UTF-8 characters in comments causing error: invalid multibyte char (US-ASCII)

### DIFF
--- a/lib/puppet/face/node/classify.rb
+++ b/lib/puppet/face/node/classify.rb
@@ -7,7 +7,7 @@ Puppet::Face.define :node, '0.0.1' do
       Make Puppet Dashboard aware of a newly created agent
       node and add it to a node group, thus allowing it to
       receive proper configurations on its next run. This
-      action will have no material effect unless you’re using
+      action will have no material effect unless you're using
       Puppet dashboard for node classification.
 
       This action is not restricted to cloud machine instances.

--- a/lib/puppet/face/node/init.rb
+++ b/lib/puppet/face/node/init.rb
@@ -5,9 +5,9 @@ Puppet::Face.define :node, '0.0.1' do
     summary 'Install Puppet on a node and clasify it'
     description <<-EOT
       Install Puppet Enterprise on an arbitrary system
-      (see “install”), classify it in Dashboard (see
-       “classify”), and automatically sign its certificate
-      request (using the certificate face’s sign action).
+      (see "install"), classify it in Dashboard (see
+       "classify"), and automatically sign its certificate
+      request (using the certificate face's sign action).
     EOT
     Puppet::CloudPack.add_init_options(self)
     when_invoked do |server, options|


### PR DESCRIPTION
There are UTF-8 characters in the comments of the files:

```
lib/puppet/face/node/classify.rb
lib/puppet/face/node/init.rb
```

The multibyte characters causes error on Ruby 1.8.7 and also need not be UTF-8.
