### PR TITLE
(#9618) PE script should accept any tar gz

### DIFF
--- a/lib/puppet/cloudpack/scripts/puppet-enterprise.erb
+++ b/lib/puppet/cloudpack/scripts/puppet-enterprise.erb
@@ -1,7 +1,10 @@
+#!/bin/bash
 # this assumes that the payload has already been delivered
 cd <%= options[:tmp_dir] %>
 # copied by the install action of cloudpack
-tar -xvzf puppet.tar.gz
+install_dir=puppet-enterprise
+mkdir $install_dir
+tar -xvzf puppet.tar.gz --strip-components 1 -C $install_dir >& foo
 grep -q '^q_puppetagent_certname' puppet.answers && (echo 'PE answers file already contains line q_puppetagent_certname';exit 1)
 echo "q_puppetagent_certname='<%= options[:certname] %>'" >> puppet.answers
-puppet-enterprise-<%= options[:pe_version] ? options[:pe_version] : '1.1' %>-all/puppet-enterprise-installer -a puppet.answers >& install.log
+$install_dir/puppet-enterprise-installer -a puppet.answers >& install.log


### PR DESCRIPTION
The PE installation script should allow the user
to just specify the payload to install and not
have to worry about it conforming to any specific
format or knowing what version it represents.

This patch allows this.
