### PR TITLE
(#9699) Fix keyname option

### DIFF
--- a/lib/puppet/cloudpack.rb
+++ b/lib/puppet/cloudpack.rb
@@ -395,7 +395,7 @@ module Puppet::CloudPack
       # TODO: Can this throw errors?
       server     = create_server(connection.servers,
         :image_id   => options[:image],
-        :key_name   => options[:keypair],
+        :key_name   => options[:keyname],
         :groups     => options[:group],
         :flavor_id  => options[:type]
       )


### PR DESCRIPTION
Previously, the keyname of the created instance
was not being set.

Now, the keyname will be set on a created instance
