### PR TITLE
(#9805) Ensure tempfiles do not get garbage collected

### DIFF
--- a/spec/unit/puppet/face/node/install_spec.rb
+++ b/spec/unit/puppet/face/node/install_spec.rb
@@ -4,11 +4,14 @@ require 'tempfile'
 
 describe Puppet::Face[:node, :current] do
   before :each do
+    @keyfile = Tempfile.new('file_on_disk.txt')
+    @installer_payload = Tempfile.new('some.tar.gz')
+    @installer_answers = Tempfile.new('some.answers')
     @options = {
       :login             => 'ubuntu',
-      :keyfile           => Tempfile.new('file_on_disk.txt').path,
-      :installer_payload => Tempfile.new('some.tar.gz').path,
-      :installer_answers => Tempfile.new('some.answers').path
+      :keyfile           => @keyfile.path,
+      :installer_payload => @installer_payload.path,
+      :installer_answers => @installer_answers.path
     }
     ENV['SSH_AUTH_SOCK'] = '/tmp/foo.socket'
   end


### PR DESCRIPTION
Previously, the actual reference was not being saved so
it could be garbage collected.

Now, the tempfile references are assigned to an instance
variables so that they do not get garbage collected.
