### PR TITLE
(#9563) Retry when Errno::ETIMEDOUT is encountered.

### DIFF
--- a/lib/puppet/cloudpack.rb
+++ b/lib/puppet/cloudpack.rb
@@ -648,6 +648,7 @@ module Puppet::CloudPack
         else
           Puppet.info "Failed to connect with issue #{e} (Retry #{retries})"
           Puppet.info "This may be because the machine is booting.  Retrying the connection..."
+          retry
         end
       rescue Errno::ECONNRESET => e
         if (retries += 1) > 10


### PR DESCRIPTION
The code was mistakenly not retrying when the
exception Errno::ETIMEDOUT is encountered.

This commit adds the missing retry
