### PR TITLE
(#10059) Handle nodes post to dashboard response correctly

### DIFF
--- a/lib/puppet/cloudpack.rb
+++ b/lib/puppet/cloudpack.rb
@@ -382,7 +382,7 @@ module Puppet::CloudPack
           # create the node if it does not exist
           data = { 'node' => { 'name' => certname } }
           response = http.post('/nodes.json', data.to_pson, headers)
-          handle_json_response(response, 'Registering node', '201').first
+          handle_json_response(response, 'Registering node', '201')
         end
         node_id = node_info['id']
 

--- a/spec/unit/puppet/cloudpack_spec.rb
+++ b/spec/unit/puppet/cloudpack_spec.rb
@@ -287,7 +287,7 @@ describe Puppet::CloudPack do
         http_response_mock(:body => '[{"name":"foo","id":"1"}]')
       end
       let :ok_add do
-        http_response_mock(:code => '201', :body => '[{"id":"1"}]')
+        http_response_mock(:code => '201', :body => '{"id":"1"}')
       end
       let :ok_member_list do
         http_response_mock(:body => '[{"node_group_id":"1", "node_id":"1"}]')


### PR DESCRIPTION
The code was incorrectly assuming that the call returned
an array when it is in fact returning a hash.

This commit updates the codes and tests to expect a hash
with a single node as the response body.
