### PR TITLE
(#10057) Pass keyfile to the ssh_remote_execute

### DIFF
--- a/lib/puppet/cloudpack.rb
+++ b/lib/puppet/cloudpack.rb
@@ -635,7 +635,8 @@ module Puppet::CloudPack
 
       # Determine the certificate name as reported by the remote system.
       certname_command = "#{cmd_prefix}puppet agent --configprint certname"
-      results = ssh_remote_execute(server, options[:login], certname_command)
+      results = ssh_remote_execute(server, options[:login], certname_command, options[:keyfile])
+
       if results[:exit_code] == 0 then
         puppetagent_certname = results[:stdout].strip
       else
@@ -665,33 +666,38 @@ module Puppet::CloudPack
       # if the end user specifies --keyfile=agent
       ssh_opts = keyfile ? { :keys => [ keyfile ] } : { }
       # Start
-      Net::SSH.start(server, login, ssh_opts) do |session|
-        session.open_channel do |channel|
-          channel.on_data do |ch, data|
-            buffer << data
-            stdout << data
-            if buffer =~ /\n/
-              lines = buffer.split("\n")
-              buffer = lines.length > 1 ? lines.pop : String.new
-              lines.each do |line|
-                Puppet.debug(line)
+      begin
+        Net::SSH.start(server, login, ssh_opts) do |session|
+          session.open_channel do |channel|
+            channel.on_data do |ch, data|
+              buffer << data
+              stdout << data
+              if buffer =~ /\n/
+                lines = buffer.split("\n")
+                buffer = lines.length > 1 ? lines.pop : String.new
+                lines.each do |line|
+                  Puppet.debug(line)
+                end
               end
             end
-          end
-          channel.on_eof do |ch|
-            # Display anything remaining in the buffer
-            unless buffer.empty?
-              Puppet.debug(buffer)
+            channel.on_eof do |ch|
+              # Display anything remaining in the buffer
+              unless buffer.empty?
+                Puppet.debug(buffer)
+              end
             end
+            channel.on_request("exit-status") do |ch, data|
+              exit_code = data.read_long
+              Puppet.debug("SSH Command Exit Code: #{exit_code}")
+            end
+            # Finally execute the command
+            channel.exec(command)
           end
-          channel.on_request("exit-status") do |ch, data|
-            exit_code = data.read_long
-            Puppet.debug("SSH Command Exit Code: #{exit_code}")
-          end
-          # Finally execute the command
-          channel.exec(command)
         end
+      rescue Net::SSH::AuthenticationFailed => user
+        raise Puppet::Error, "Authentication failure for user #{user}. Please check the keyfile and try again."
       end
+
       Puppet.info "Executing remote command ... Done"
       { :exit_code => exit_code, :stdout => stdout }
     end

--- a/spec/unit/puppet/cloudpack_spec.rb
+++ b/spec/unit/puppet/cloudpack_spec.rb
@@ -228,17 +228,19 @@ describe Puppet::CloudPack do
         @options[:login] = 'dan'
         Puppet::CloudPack.expects(:ssh_connect).with(@server, 'dan', @keyfile.path).returns(@mock_connection_tuple)
         @is_command_valid = false
+        @has_keyfile = true
         Puppet::CloudPack.expects(:ssh_remote_execute).times(3).with do |server, login, command, keyfile|
           if command =~ /^sudo bash -c 'chmod u\+x \S+gems\.sh; \S+gems\.sh'/
             # set that the command is valid when it matches the regex
             # the test will pass is this is set to true
             @is_command_valid = true
-          else
-            true
           end
+          @has_keyfile = keyfile == @keyfile.path and @has_keyfile
+          true
         end.returns(ssh_remote_execute_return_hash)
         subject.install(@server, @options)
         @is_command_valid.should be_true
+        @has_keyfile.should be_true
       end
       it 'should not add sudo to command when login is root' do
         @options[:login] = 'root'


### PR DESCRIPTION
When getting the certname from the agent, the keyfile
wasn't being passed to ssh_remote_execute.

This caused an authentication failure.  

Unfortunately, this wasn't clear from the error.

This commit also catches the Net::SSH::AuthenticationFailure
exception inside the ssh_remote_execute and passes
all other exceptions to be handled by the calling method.
