### PR TITLE
Adding a new `retry_action` method

### DIFF
--- a/lib/puppet/cloudpack/util/util.rb
+++ b/lib/puppet/cloudpack/util/util.rb
@@ -1,0 +1,18 @@
+module Puppet::CloudPack::Util
+  class RetryException < Exception
+  end
+  
+  def self.retry_action(retries=3, pause=0)
+    # Helper method to retry actions n number of times, re-raise the exception
+    # after the retry count has been met.
+    unless block_given?
+      raise RetryException, 'No block given'
+    end
+    begin
+      yield
+    rescue 
+      sleep pause if pause > 0
+      retry if (retries -= 1) > 0 else raise
+    end
+  end
+end

--- a/spec/unit/puppet/util/util_spec.rb
+++ b/spec/unit/puppet/util/util_spec.rb
@@ -1,0 +1,20 @@
+require 'spec_helper'
+require 'puppet/cloudpack/util/util'
+
+
+describe Puppet::CloudPack::Util do
+  describe 'retry_action' do
+    it "should require a block" do
+      expect {Puppet::CloudPack::Util.retry_action(retries=2)}.to raise_error(Puppet::CloudPack::Util::RetryException, 'No block given')
+    end
+    
+    it "should retry the number of retries specified" do
+      attempts = 0
+      Puppet::CloudPack::Util.retry_action(retries=3) do
+        attempts += 1
+        raise
+      end
+      attempts.should == 3
+    end
+  end 
+end


### PR DESCRIPTION
Adding a generic `retry_action` method to handle the various situations where CP should gracefully handle temporary service outages or slowness.
