### PR TITLE
Retry creation of tags if it fails

### DIFF
--- a/lib/puppet/cloudpack.rb
+++ b/lib/puppet/cloudpack.rb
@@ -5,6 +5,7 @@ require 'fog'
 require 'net/ssh'
 require 'puppet/network/http_pool'
 require 'puppet/cloudpack/progressbar'
+require 'puppet/cloudpack/utils'
 require 'timeout'
 
 module Puppet::CloudPack
@@ -894,11 +895,13 @@ module Puppet::CloudPack
 
     def create_tags(tags, server)
       Puppet.notice('Creating tags for instance ...')
-      tags.create(
-        :key         => 'Created-By',
-        :value       => 'Puppet',
-        :resource_id => server.id
-      )
+      Puppet::CloudPack::Utils.retry_action(10,2) do
+        tags.create(
+          :key         => 'Created-By',
+          :value       => 'Puppet',
+          :resource_id => server.id
+        )
+      end
       Puppet.notice('Creating tags for instance ... Done')
     end
 


### PR DESCRIPTION
When creating the tags of a new instance, the meta data for the instance may not be ready on Amazons side. Retry tagging for up to 10 times sleeping for 2 seconds between tries.
