### PR TITLE
Refactor the Puppet::CloudPack::Utils#retry_action method

### DIFF
--- a/lib/puppet/cloudpack/utils.rb
+++ b/lib/puppet/cloudpack/utils.rb
@@ -12,7 +12,11 @@ module Puppet::CloudPack::Utils
       yield
     rescue 
       sleep pause if pause > 0
-      retry if (retries -= 1) > 0 else raise
+      if (retries -= 1) > 0
+        retry
+      else 
+        raise
+      end
     end
   end
 end


### PR DESCRIPTION
The structure of the retry if/else line was causing failures.  Laying it out in to multiple lines solved the issue
