### PR TITLE
(#10178) Use the Puppet::CloudPack::Utils#retry_action method

### DIFF
--- a/lib/puppet/cloudpack.rb
+++ b/lib/puppet/cloudpack.rb
@@ -5,6 +5,7 @@ require 'fog'
 require 'net/ssh'
 require 'puppet/network/http_pool'
 require 'puppet/cloudpack/progressbar'
+require 'puppet/cloudpack/utils'
 require 'timeout'
 
 module Puppet::CloudPack
@@ -894,11 +895,13 @@ module Puppet::CloudPack
 
     def create_tags(tags, server)
       Puppet.notice('Creating tags for instance ...')
-      tags.create(
-        :key         => 'Created-By',
-        :value       => 'Puppet',
-        :resource_id => server.id
-      )
+      Puppet::CloudPack::Utils.retry_action( :timeout => 120 ) do
+        tags.create(
+          :key         => 'Created-By',
+          :value       => 'Puppet',
+          :resource_id => server.id
+        )
+      end
       Puppet.notice('Creating tags for instance ... Done')
     end
 


### PR DESCRIPTION
The create_tags method would fail if instance wasn't ready for modifications

Now we retry for two minutes if we fail to create tags
