### PR TITLE
(#10206) Use exception class as key

### DIFF
--- a/lib/puppet/cloudpack.rb
+++ b/lib/puppet/cloudpack.rb
@@ -732,13 +732,13 @@ module Puppet::CloudPack
 
       retry_exceptions = {
           Net::SSH::AuthenticationFailed => "Failed to connect. This may be because the machine is booting.\nRetrying the connection...",
-          Errno::ECONNREFUSED            => " Failed to connect.\nThis may be because the machine is booting.  Retrying the connection...",
-          Errno::ETIMEDOUT               => "Failed to connect.\nThis may be because the machine is booting.  Retrying the connection..",
-          Errno::ECONNRESET              => "Connection reset.\nRetrying the connection...",
-          Timeout::Error                 => "Connection test timed-out.\nThis may be because the machine is booting.  Retrying the connection..."
+          Errno::ECONNREFUSED            => "Failed to connect. This may be because the machine is booting.  Retrying the connection...",
+          Errno::ETIMEDOUT               => "Failed to connect. This may be because the machine is booting.  Retrying the connection..",
+          Errno::ECONNRESET              => "Connection reset. Retrying the connection...",
+          Timeout::Error                 => "Connection test timed-out. This may be because the machine is booting.  Retrying the connection..."
       }
 
-      Puppet::CloudPack::Utils.retry_action( :timeout => 250, :retry_exceptions => retry_exceptions ) do 
+      Puppet::CloudPack::Utils.retry_action( :timeout => 250, :retry_exceptions => retry_exceptions ) do
         Timeout::timeout(25) do
           ssh_remote_execute(server, login, "date", keyfile)
         end

--- a/lib/puppet/cloudpack/utils.rb
+++ b/lib/puppet/cloudpack/utils.rb
@@ -3,16 +3,16 @@ module Puppet::CloudPack::Utils
   class RetryException::NoBlockGiven < RetryException; end
   class RetryException::NoTimeoutGiven < RetryException;end
   class RetryException::Timeout < RetryException; end
-  
+
   def self.retry_action( parameters = { :retry_exceptions => nil, :timeout => nil } )
     # Retry actions for a specified amount of time. This method will allow the final
     # retry to complete even if that extends beyond the timeout period.
     unless block_given?
       raise RetryException::NoBlockGiven
     end
-    
+
     raise RetryException::NoTimeoutGiven if parameters[:timeout].nil?
-    parameters[:retry_exceptions] ||= Hash.new 
+    parameters[:retry_exceptions] ||= Hash.new
 
     start = Time.now
     failures = 0
@@ -23,31 +23,29 @@ module Puppet::CloudPack::Utils
       # If we were giving exceptions to catch,
       # catch the excptions we care about and retry.
       # All others fail hard
-      
+
       raise RetryException::Timeout if timedout?(start, parameters[:timeout])
-      
+
       if (not parameters[:retry_exceptions].keys.empty?) and parameters[:retry_exceptions].keys.include?(e.class)
-        Puppet.info("Caught exception #{e}")
-        Puppet.info(parameters[:retry_exceptions][e])
+        Puppet.info("Caught exception #{e.class}:#{e}")
+        Puppet.info(parameters[:retry_exceptions][e.class])
       elsif (not parameters[:retry_exceptions].keys.empty?)
         # If the exceptions is not in the list of retry_exceptions re-raise.
         raise e
-      end  
-        
+      end
+
       failures += 1
-    
       # Increase the amount of time that we sleep after every
       # failed retry attempt.
       sleep (((2 ** failures) -1) * 0.1)
 
       retry
-      
+
     end
   end
-  
+
   def self.timedout?(start, timeout)
     return true if timeout.nil?
-    
     (Time.now - start) >= timeout
   end
 end


### PR DESCRIPTION
The code was incorrectly using the instance of the
exception instead of the class constant. This was
causing it to try to pass nil to the info method
which resulted in an error.

This commit uses the class constant instead of the
instance.

It also removes some trailing whitespace and cleans
up the exception messages.
