### PR TITLE
(#10235) Add keyname to list of attributes

### DIFF
--- a/lib/puppet/cloudpack.rb
+++ b/lib/puppet/cloudpack.rb
@@ -539,7 +539,7 @@ module Puppet::CloudPack
         hsh[s.id] = {
           "id"         => s.id,
           "state"      => s.state,
-          "key_name"   => s.key_name,
+          "keyname"    => s.key_name,
           "dns_name"   => s.dns_name,
           "created_at" => s.created_at,
         }


### PR DESCRIPTION
When listing instances, include the keyname in the attributes.

This should be merged post PE 2.0 release.
