### PR TITLE
(#8676) Catch the Errno::EHOSTUNREACH exception and retry

### DIFF
--- a/lib/puppet/cloudpack.rb
+++ b/lib/puppet/cloudpack.rb
@@ -732,6 +732,7 @@ module Puppet::CloudPack
 
       retry_exceptions = {
           Net::SSH::AuthenticationFailed => "Failed to connect. This may be because the machine is booting.\nRetrying the connection...",
+          Errno::EHOSTUNREACH            => "Failed to connect. This may be because the machine is booting.  Retrying the connection..",
           Errno::ECONNREFUSED            => "Failed to connect. This may be because the machine is booting.  Retrying the connection...",
           Errno::ETIMEDOUT               => "Failed to connect. This may be because the machine is booting.  Retrying the connection..",
           Errno::ECONNRESET              => "Connection reset. Retrying the connection...",


### PR DESCRIPTION
This patch adds the Net::SSH Errno::EHOSTUNREACH exception to the list of exceptions that should be handled by the `Puppet::CloudPack::Utils.retry_action`.
