### PR TITLE
(#10184) Fix 2 failing specs for CP installer method

### DIFF
--- a/spec/unit/puppet/cloudpack_spec.rb
+++ b/spec/unit/puppet/cloudpack_spec.rb
@@ -231,7 +231,7 @@ describe Puppet::CloudPack do
         @is_command_valid = false
         @has_keyfile = true
         Puppet::CloudPack.expects(:ssh_remote_execute).times(3).with do |server, login, command, keyfile|
-          if command =~ /^sudo bash -c 'chmod u\+x \S+gems\.sh; \S+gems\.sh'/
+          if command =~ /^sudo bash -c 'chmod u\+x \S+puppet-community\.sh; \S+puppet-community\.sh'/
             # set that the command is valid when it matches the regex
             # the test will pass is this is set to true
             @is_command_valid = true
@@ -248,7 +248,7 @@ describe Puppet::CloudPack do
         Puppet::CloudPack.expects(:ssh_connect).with(@server, 'root', @keyfile.path).returns(@mock_connection_tuple)
         @is_command_valid = false
         Puppet::CloudPack.expects(:ssh_remote_execute).times(3).with do |server, login, command, keyfile|
-          if command =~ /^bash -c 'chmod u\+x \S+gems\.sh; \S+gems\.sh'/
+          if command =~ /^bash -c 'chmod u\+x \S+puppet-community\.sh; \S+puppet-community\.sh'/
             # set that the command is valid when it matches the regex
             # the test will pass is this is set to true
             @is_command_valid = true


### PR DESCRIPTION
Two specs were not updated when the switch was made to use the
puppet-community install script as the default installation script used
by the CP bootstrap and install commands.

The errors from the failing specs where a bit misleading, they
suggested there was a problem with prepending `sudo` to commands
generated by CP bootstrap and install commands. The real problem was due
to the fact that both failing specs where expecting the install command
generated by CP to use `gems.sh` instead of the new default
`puppet-community.sh`.
