### PR TITLE
(#10655) Add positional arguments to puppet help node

### DIFF
--- a/lib/puppet/face/node/classify.rb
+++ b/lib/puppet/face/node/classify.rb
@@ -4,10 +4,11 @@ Puppet::Face.define :node, '0.0.1' do
   action :classify do
     summary 'Add a node to a dashboard group'
     description <<-EOT
-      Make The External Node Classifier aware of a newly created agent
-      and classify it. This only supports the Dashboard as a node classifier
-      and assigns the node to a group.  The group itself is expected to have
-      classes the node should receive in its configuration catalog
+      Add node <certname> to a dashboard group.  Make The External Node
+      Classifier aware of a newly created agent and classify it. This only
+      supports the Dashboard as a node classifier and assigns the node to a
+      group.  The group itself is expected to have classes the node should
+      receive in its configuration catalog
 
       Classification of a node will allow it to receive proper configurations
       on its next run
@@ -25,6 +26,8 @@ Puppet::Face.define :node, '0.0.1' do
         --node-group pe_agents \
         agent01.puppetlabs.lan
     EOEXAMPLE
+
+    arguments '<certname>'
 
     when_rendering :console do |return_value|
       return_value['status'] || 'OK'

--- a/lib/puppet/face/node/install.rb
+++ b/lib/puppet/face/node/install.rb
@@ -2,12 +2,15 @@ require 'puppet/cloudpack'
 
 Puppet::Face.define :node, '0.0.1' do
   action :install do
-    summary 'Install Puppet on an arbitrary node'
+    summary 'Install Puppet on a running node'
     description <<-EOT
-      Installs Puppet on an existing instance. It uses scp to
-      copy installation requirements to the machine and ssh to
-      run the installation commmands remotely.
+      Installs Puppet on an existing node at <hostname or ip>. It uses scp to
+      copy installation requirements to the machine and ssh to run the
+      installation commmands remotely.
     EOT
+
+    arguments '<hostname or ip>'
+
     Puppet::CloudPack.add_install_options(self)
     when_rendering :console do |return_value|
       return_value.keys.sort.collect { |k| "%20.20s: %-20s" % [k, return_value[k]] }.join("\n")

--- a/lib/puppet/face/node_aws/fingerprint.rb
+++ b/lib/puppet/face/node_aws/fingerprint.rb
@@ -14,6 +14,9 @@ fingerprint.  If one is found, the fingerprint is returned otherwise a warning
 is displayed.  In either case, if this command returns without an error then
 the system is ready for use.
     EOT
+
+    arguments '<instance name>'
+
     Puppet::CloudPack.add_fingerprint_options(self)
     when_invoked do |server, options|
       Puppet::CloudPack.fingerprint(server, options)

--- a/lib/puppet/face/node_aws/terminate.rb
+++ b/lib/puppet/face/node_aws/terminate.rb
@@ -5,10 +5,12 @@ Puppet::Face.define :node_aws, '0.0.1' do
   action :terminate do
     summary 'Terminate an EC2 machine instance'
     description <<-EOT
-      Terminates an instance.
-      Accepts the instance name to terminate
-      as the only argument.
+      Terminate the instance identified by <instance name>.  Accepts the
+      instance name to terminate as the only argument.
     EOT
+
+    arguments '<instance name>'
+
     Puppet::CloudPack.add_terminate_options(self)
     when_invoked do |server, options|
       Puppet::CloudPack.terminate(server, options)


### PR DESCRIPTION
Without this patch puppet help node {install,classify} and puppet help
node_aws {fingerprint,terminate} all require positional arguments but
did not mention this in the inline help.

This patch fixes the problem by adding the arguments attribute to each
face action in cloud provisioner that requires a positional argument to
be specified.
