### PR TITLE
(#10810) Add support for Rackspace Cloud Servers

### DIFF
--- a/docs/Rackspace.markdown
+++ b/docs/Rackspace.markdown
@@ -1,0 +1,132 @@
+# Cloud Provisioner Rackspace Support #
+
+This Puppet module adds Rackspace support to Cloud Provisioner.
+
+## Getting started ##
+
+The node_rackspace requires fog gem.
+
+    $ gem install fog
+
+Add your Rackspace Cloud Server credentials to the fog configuration file.
+
+    # ~/.fog
+    default:
+      :rackspace_username: rackspaceuser
+      :rackspace_api_key: XXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXX
+
+## Creating Rackspace Cloud Servers ##
+
+Creating new Rackspace Cloud Servers
+
+    $ puppet node_rackspace create -f 1 -i 104 -n demo
+
+    notice: Connecting ...
+    notice: Connected to Rackspace
+    notice: Complete
+    20365648:
+      name:      demo
+      serverid:  20365648
+      hostid:    2ff006e68257221aa583f5bb2753a622
+      ipaddress: 50.57.180.98
+      state:     BUILD
+      progress:  0
+      password:  *************
+
+
+Create a Rackspace Cloud server and unmask the admin password in the output.
+
+    $ puppet node_rackspace create -f 1 -i 104 -n demo --show-password
+
+Create a Rackspace Cloud server and wait for it to boot.
+
+    $ puppet node_rackspace create -f 1 -i 104 -n demo -w
+
+Create a Rackspace Cloud Server, wait for it to boot, then add the specificed SSH public key.
+
+    $ puppet node_rackspace create -f 1 -i 104 -n demo -p ~/.ssh/id_rsa.pub
+
+## Listing image, flavors, and servers ##
+
+Listing servers.
+
+    $ puppet node_rackspace list servers
+
+    notice: Connecting ...
+    notice: Connected to Rackspace
+    notice: Complete
+    20365648:
+      name:      demo
+      serverid:  20365648
+      hostid:    2ff006e68257221aa583f5bb2753a622
+      ipaddress: 50.57.180.98
+      state:     BUILD
+      progress:  100
+
+
+Listing images.
+
+    $ puppet node_rackspace list images
+
+    notice: Connecting ...
+    notice: Connected to Rackspace
+    notice: Complete
+    Windows Server 2008 R2 x64 - SQL Web:
+      id:      81
+      updated: 2011-10-04T08:39:34-05:00
+      status:  ACTIVE
+
+    Ubuntu 10.04 LTS (lucid):
+      id:      49
+      updated: 2011-11-05T09:34:30-05:00
+      status:  ACTIVE
+
+    Oracle EL Server Release 5 Update 4:
+      id:      40
+      updated: 2010-10-28T11:40:20-05:00
+      status:  ACTIVE
+
+    Ubuntu 9.10 (karmic):
+      id:      14362
+      updated: 2009-11-06T05:09:40-06:00
+      status:  ACTIVE
+
+    ...
+
+
+Listing flavors.
+
+    $ puppet node_rackspace list flavors
+
+    notice: Connecting ...
+    notice: Connected to Rackspace
+    notice: Complete
+    256 server:
+      id:   1
+      ram:  256
+      disk: 10
+
+    512 server:
+      id:   2
+      ram:  512
+      disk: 20
+
+    1GB server:
+      id:   3
+      ram:  1024
+      disk: 40
+
+    ...
+
+
+## Rebooting Servers ##
+
+Servers can be rebooted by server id.
+
+    $ puppet node_rackspace terminate 12345678
+
+## Terminating Servers ##
+
+Servers can be terminated by server id.
+
+    $ puppet node_rackspace terminate 12345678

--- a/lib/puppet/application/node_rackspace.rb
+++ b/lib/puppet/application/node_rackspace.rb
@@ -1,0 +1,4 @@
+require 'puppet/application/face_base'
+
+class Puppet::Application::Node_rackspace < Puppet::Application::FaceBase
+end

--- a/lib/puppet/cloudpack/rackspace.rb
+++ b/lib/puppet/cloudpack/rackspace.rb
@@ -1,0 +1,107 @@
+require 'fog'
+
+module Puppet::CloudPack
+  class Rackspace
+
+    attr_accessor :connection
+
+    def initialize(options, connection=nil)
+      @options    = options
+      @connection = connection || create_connection
+    end
+
+    def create_connection(options = {})
+      Puppet.notice "Connecting ..."
+      connection = Fog::Compute[:rackspace]
+      Puppet.notice "Connected to Rackspace"
+      connection
+    end
+
+    def list_images
+      images = @connection.list_images_detail.attributes
+      {:kind => @options[:kind], :images => images[:body]['images']}
+    end
+
+    def list_flavors
+      flavors = @connection.list_flavors_detail.attributes
+      {:kind => @options[:kind], :flavors => flavors[:body]['flavors']}
+    end
+
+    def list_servers
+      servers = @connection.servers
+      if servers.empty?
+        s = {}
+      else
+        s = servers.collect {|s| s.attributes}
+      end
+      {:kind => @options[:kind], :servers => s}
+    end
+
+    def create
+      # Both image_id and flavor_id must be integers.
+      # FIXME image_id and flavor_id should be validated.
+      new_attributes = {
+        :image_id  => @options[:image_id].to_i,
+        :flavor_id => @options[:flavor_id].to_i,
+        :name => @options[:name],
+        :public_key_path => @options[:public_key],
+        :username => @options[:root]
+      }
+      server = @connection.servers.create(new_attributes)
+
+      # We cannot upload the SSH public key until the Rackspace
+      # Cloud Server is fully booted.
+      if @options[:public_key] | @options[:wait_for_boot]
+        Puppet.notice "Waiting for server to boot ..."
+        server.wait_for { ready? }
+      end
+      if @options[:public_key]
+        Puppet.notice "Adding SSH public key ..."
+        server.setup(:password => server.password)
+      end
+
+      # The login password is masked with '*' characters unless
+      # the --show-password option is set to true.
+      password = get_admin_password(server, @options[:show_password])
+      [{:password => password, :status => 'success'}.merge(server.attributes)]
+    end
+
+    def get_admin_password(server, show_password=false)
+      if show_password
+        server.password
+      else
+        server.password.gsub(/./, '*')
+      end
+    end
+
+    def find
+      server = @connection.servers.get(@options[:server_id])
+      if server.nil?
+        Puppet.notice "Cannot find a server with id: #{@options[:server_id]}"
+        []
+      else
+        [server.attributes]
+      end
+    end
+
+    def reboot
+      server = @connection.servers.get(@options[:server_id])
+      if server.nil?
+        Puppet.notice "Cannot find a server with id: #{@options[:server_id]}"
+      else
+        server.reboot
+      end
+      {'status' => 'success'}
+    end
+
+    def terminate
+      server = @connection.servers.get(@options[:server_id])
+      if server.nil?
+        Puppet.notice "Cannot find a server with id: #{@options[:server_id]}"
+      else
+        server.destroy
+      end
+      {'status' => 'success'}
+    end
+  end
+end

--- a/lib/puppet/face/node_rackspace.rb
+++ b/lib/puppet/face/node_rackspace.rb
@@ -1,0 +1,11 @@
+require 'puppet/indirector/face'
+
+Puppet::Face.define(:node_rackspace, '0.0.1') do
+  copyright "Puppet Labs", 2011
+  license   "Puppet Enterprise Software License Agreement"
+
+  summary "View and manage Rackspace Cloud Servers"
+  description <<-'EOT'
+    View and manage Rackspace Cloud Servers
+  EOT
+end

--- a/lib/puppet/face/node_rackspace/create.rb
+++ b/lib/puppet/face/node_rackspace/create.rb
@@ -1,0 +1,107 @@
+require 'puppet/face'
+require 'puppet/cloudpack/rackspace'
+
+Puppet::Face.define(:node_rackspace, '0.0.1') do
+  action :create do
+    summary "Create Rackspace Cloud Servers"
+    description <<-'EOT'
+      Create Rackspace Cloud Servers.
+    EOT
+
+    returns 'Array of Cloud Server attribute hashes.'
+
+    examples <<-'EOT'
+    Create a Rackspace Cloud server.
+
+      $ puppet node_rackspace create -f 1 -i 104 -n demo
+
+    Create a Rackspace Cloud server and unmask the admin password in the output.
+
+      $ puppet node_rackspace create -f 1 -i 104 -n demo --show-password
+
+    Create a Rackspace Cloud server and wait for it to boot.
+
+      $ puppet node_rackspace create -f 1 -i 104 -n demo -w
+
+    Create a Rackspace Cloud Server, wait for it to boot, then add the specificed SSH public key.
+
+      $ puppet node_rackspace create -f 1 -i 104 -n demo -p ~/.ssh/id_rsa.pub
+    EOT
+
+    option '--flavor-id=', '-f=' do
+      required
+      summary 'The Rackspace Cloud Server flavor id.'
+      description <<-'EOT'
+        A flavor is an available hardware configuration for a server.
+        Each flavor has a unique combination of disk space, memory capacity
+        and priority for CPU time. Flavors are identified by id. Use the
+        puppet node_rackspace list flavors command to get a list of
+        available flavors.
+      EOT
+    end
+
+    option '--image-id=', '-i=' do
+      required
+      summary 'The Rackspace Cloud Server image id.'
+      description <<-'EOT'
+        An image is a collection of files used to create or rebuild a server.
+        Images are identified by id. Use the puppet node_rackspace list images
+        command to get list of available images.
+      EOT
+    end
+
+    option '--name=', '-n=' do
+      summary 'The Rackspace Cloud Server name.'
+      description <<-'EOT'
+        The Rackspace Cloud Server name attribute. Note, server names are not
+        unique across servers. When referring to a specific server, the
+        server id should be used.
+      EOT
+    end
+
+    option '--public-key=', '-p=' do
+      default_to { nil }
+      summary 'The SSH public key path on disk.'
+      description <<-'EOT'
+        The path to the SSH public key on disk, which will be uploaded to the
+        server once it has completed the provisioning process.
+      EOT
+    end
+
+    option '--show-password' do
+      default_to { false }
+      summary 'Show the instance root password.'
+      description <<-'EOT'
+        Toggle the visibility of the root password in the output following the
+        creating of a new Rackspace Cloud Server.
+      EOT
+    end
+
+    option '--wait-for-boot', '-w' do
+      default_to { false }
+      summary 'Wait for server to boot'
+      description <<-'EOT'
+        Wait for the server to boot.
+      EOT
+    end
+
+    when_invoked do |options|
+      rackspace = Puppet::CloudPack::Rackspace.new(options)
+      rackspace.create
+    end
+
+    when_rendering :console do |return_value|
+      Puppet.notice "Complete"
+      return_value.map do |server|
+        "#{server[:id]}:\n" <<
+        "  name:      #{server[:name]}\n" <<
+        "  serverid:  #{server[:id]}\n" <<
+        "  hostid:    #{server[:host_id]}\n" <<
+        "  ipaddress: #{server[:addresses]["public"]}\n" <<
+        "  state:     #{server[:state]}\n" <<
+        "  progress:  #{server[:progress]}\n" <<
+        "  password:  #{server[:password]}\n"
+      end.join("\n")
+    end
+  end
+end

--- a/lib/puppet/face/node_rackspace/find.rb
+++ b/lib/puppet/face/node_rackspace/find.rb
@@ -1,0 +1,38 @@
+require 'puppet/face'
+require 'puppet/cloudpack/rackspace'
+
+Puppet::Face.define(:node_rackspace, '0.0.1') do
+  action :find do
+    summary "Find Rackspace Cloud Servers"
+    description <<-'EOT'
+      Find Rackspace Cloud Servers by server id.
+    EOT
+
+    returns 'Array of Cloud Server attribute hashes.'
+
+    examples <<-'EOT'
+      $ puppet node_rackspace find 12345678
+    EOT
+
+    arguments "<server_id>"
+
+    when_invoked do |server_id, options|
+      options[:server_id] = server_id
+      rackspace = Puppet::CloudPack::Rackspace.new(options)
+      rackspace.find
+    end
+
+    when_rendering :console do |return_value|
+      Puppet.notice "Complete"
+      return_value.map do |server|
+        "#{server[:id]}:\n" <<
+        "  name:      #{server[:name]}\n" <<
+        "  serverid:  #{server[:id]}\n" <<
+        "  hostid:    #{server[:host_id]}\n" <<
+        "  ipaddress: #{server[:addresses]["public"]}\n" <<
+        "  state:     #{server[:state]}\n" <<
+        "  progress:  #{server[:progress]}\n"
+      end.join("\n")
+    end
+  end
+end

--- a/lib/puppet/face/node_rackspace/list.rb
+++ b/lib/puppet/face/node_rackspace/list.rb
@@ -1,0 +1,64 @@
+require 'puppet/face'
+require 'puppet/cloudpack/rackspace'
+
+Puppet::Face.define(:node_rackspace, '0.0.1') do
+  action :list do
+    summary "List Rackspace Cloud Servers"
+    description <<-'EOT'
+      List Rackspace Cloud servers, images, or flavors.
+    EOT
+
+    returns 'Array of Cloud Server attribute hashes.'
+
+    examples <<-'EOT'
+      $ puppet node_rackspace list servers
+
+      $ puppet node_rackspace list images
+
+      $ puppet node_rackspace list flavors
+    EOT
+
+    arguments "<kind>"
+
+    when_invoked do |kind, options|
+      valid_kinds = ['servers', 'images', 'flavors']
+      if valid_kinds.include?(kind)
+        options[:kind] = kind
+        rackspace = Puppet::CloudPack::Rackspace.new(options)
+        rackspace.send(:"list_#{kind}")
+      else
+        raise ArgumentError, "Invalid search type, kind must be one of [flavors, images, or servers]"
+      end
+    end
+
+    when_rendering :console do |return_value|
+      Puppet.notice "Complete"
+      case return_value[:kind]
+      when 'servers'
+        return_value[:servers].map do |server|
+          "#{server[:id]}:\n" <<
+          "  name:      #{server[:name]}\n" <<
+          "  serverid:  #{server[:id]}\n" <<
+          "  hostid:    #{server[:host_id]}\n" <<
+          "  ipaddress: #{server[:addresses]["public"]}\n" <<
+          "  state:     #{server[:state]}\n" <<
+          "  progress:  #{server[:progress]}\n"
+        end.join("\n")
+      when 'images'
+        return_value[:images].map do |image|
+          "#{image['name']}:\n" <<
+          "  id:      #{image['id']}\n" <<
+          "  updated: #{image['updated']}\n" <<
+          "  status:  #{image['status']}\n"
+        end.join("\n")
+      when 'flavors'
+        return_value[:flavors].map do |flavor|
+          "#{flavor['name']}:\n" <<
+          "  id:   #{flavor['id']}\n" <<
+          "  ram:  #{flavor['ram']}\n" <<
+          "  disk: #{flavor['disk']}\n"
+        end.join("\n")
+      end
+    end
+  end
+end

--- a/lib/puppet/face/node_rackspace/reboot.rb
+++ b/lib/puppet/face/node_rackspace/reboot.rb
@@ -1,0 +1,25 @@
+require 'puppet/face'
+require 'puppet/cloudpack/rackspace'
+
+Puppet::Face.define(:node_rackspace, '0.0.1') do
+  action :reboot do
+    summary "Reboot a Rackspace Cloud Server"
+    description <<-'EOT'
+      Reboot a single Rackspace Cloud Server by server id.
+    EOT
+
+    returns 'Hash containing the status'
+
+    examples <<-'EOT'
+      $ puppet node_rackspace reboot 12345678
+    EOT
+
+    arguments "<server_id>"
+
+    when_invoked do |server_id, options|
+      options[:server_id] = server_id
+      rackspace = Puppet::CloudPack::Rackspace.new(options)
+      rackspace.reboot
+    end
+  end
+end

--- a/lib/puppet/face/node_rackspace/terminate.rb
+++ b/lib/puppet/face/node_rackspace/terminate.rb
@@ -1,0 +1,25 @@
+require 'puppet/face'
+require 'puppet/cloudpack/rackspace'
+
+Puppet::Face.define(:node_rackspace, '0.0.1') do
+  action :terminate do
+    summary "Terminate a Rackspace Cloud Server"
+    description <<-'EOT'
+      Terminate a single Rackspace Cloud Server by server id.
+    EOT
+
+    returns 'Hash containing the status'
+
+    examples <<-'EOT'
+      $ puppet node_rackspace terminate 12345678
+    EOT
+
+    arguments "<server_id>"
+
+    when_invoked do |server_id, options|
+      options[:server_id] = server_id
+      rackspace = Puppet::CloudPack::Rackspace.new(options)
+      rackspace.terminate
+    end
+  end
+end

--- a/spec/fog-stub-configuration
+++ b/spec/fog-stub-configuration
@@ -1,3 +1,5 @@
 :default:
   :aws_access_key_id: dummy
   :aws_secret_access_key: dummy
+  :rackspace_api_key: dummy
+  :rackspace_username: dummy

--- a/spec/unit/puppet/face/node_rackspace/create_spec.rb
+++ b/spec/unit/puppet/face/node_rackspace/create_spec.rb
@@ -1,0 +1,142 @@
+require 'spec_helper'
+
+
+
+describe 'puppet node_rackspace create' do
+  subject { Puppet::Face[:node_rackspace, :current] }
+
+  server_attributes = {
+    :id        => '12345678',
+    :name      => 'slice12345678',
+    :host_id   => '277eed7bbd0aaffdebe80a3b27183837',
+    :addresses => { "public" => '127.0.0.1' },
+    :state     => 'BUILD',
+    :progress  => '0',
+  }
+
+  describe 'option validation' do
+    context 'without any options' do
+      it 'should require flavor_id' do
+        pattern = /are required.+?flavor_id/
+        expect { subject.create }.to raise_error ArgumentError, pattern
+      end
+
+      it 'should require image_id' do
+        pattern = /are required.+?image_id/
+        expect { subject.create }.to raise_error ArgumentError, pattern
+      end
+    end
+  end
+
+  describe 'the behavior of create' do
+    before :each do
+      Puppet::CloudPack::Rackspace.any_instance.stubs(:create_connection).returns(server)
+    end
+
+    let(:server) do
+      mock('Fog::Compute[:rackspace]') do
+        expects(:servers).returns(self)
+        expects(:create).returns(self)
+        expects(:password).returns('123456789!@#$')
+        expects(:attributes).returns(server_attributes)
+      end
+    end
+
+    context 'with only required arguments' do
+      let(:options) do
+        { :image_id => '123456', :flavor_id => '1' }
+      end
+
+      it 'should create a server' do
+        expected_attributes = {
+          :id        => '12345678',
+          :name      => 'slice12345678',
+          :host_id   => '277eed7bbd0aaffdebe80a3b27183837',
+          :addresses => { "public" => '127.0.0.1' },
+          :state     => 'BUILD',
+          :progress  => '0',
+          :password  => '*************',
+          :status    => 'success'
+        }
+        subject.create(options).should == [expected_attributes]
+      end
+    end
+
+    context 'when --show-password is true' do
+      let(:options) do
+        { :image_id => '123456', :flavor_id => '1', :show_password => true }
+      end
+
+      it 'should store the password in clear text' do
+        subject.create(options).first[:password].should == '123456789!@#$'
+      end
+    end
+
+    context 'when --show-password is false' do
+      let(:options) do
+        { :image_id => '123456', :flavor_id => '1', :show_password => false }
+      end
+
+      it 'should mask the password' do
+        subject.create(options).first[:password].should == '*************'
+      end
+    end
+
+    context 'when --wait-for-boot is true' do
+      let(:server) do
+        mock('Fog::Compute[:rackspace]') do
+          expects(:servers).returns(self)
+          expects(:create).returns(self)
+          expects(:password).returns('123456789!@#$')
+          expects(:attributes).returns(server_attributes)
+          expects(:ready?).returns(true)
+          expects(:wait_for).with { ready? }
+        end
+      end
+
+      let(:options) do
+        { :image_id  => '123456', :flavor_id => '1', :wait_for_boot => true }
+      end
+
+      it 'should wait for the server to boot' do
+        subject.create(options)
+      end
+    end
+
+    context 'when --wait-for-boot is false' do
+      let(:server) do
+        mock('Fog::Compute[:rackspace]') do
+          expects(:servers).returns(self)
+          expects(:create).returns(self)
+          expects(:password).returns('123456789!@#$')
+          expects(:attributes).returns(server_attributes)
+          expects(:ready?).never
+          expects(:wait_for).never
+        end
+      end
+
+      let(:options) do
+        { :image_id  => '123456', :flavor_id => '1', :wait_for_boot => false }
+      end
+
+      it 'should not wait for the server to boot' do
+        subject.create(options)
+      end
+    end
+  end
+
+  describe 'inline documentation' do
+    subject { Puppet::Face[:node_rackspace, :current].get_action :create }
+
+    its(:summary)     { should =~ /create.*rackspace/im }
+    its(:description) { should =~ /create.*rackspace/im }
+    its(:returns)     { should =~ /hash/i }
+    its(:examples)    { should_not be_empty }
+
+    %w{ license copyright summary description returns examples }.each do |doc|
+      context "of the" do
+        its(doc.to_sym) { should_not =~ /(FIXME|REVISIT|TODO)/ }
+      end
+    end
+  end
+end

--- a/spec/unit/puppet/face/node_rackspace/find_spec.rb
+++ b/spec/unit/puppet/face/node_rackspace/find_spec.rb
@@ -1,0 +1,80 @@
+require 'spec_helper'
+
+describe 'puppet node_rackspace find' do
+  subject { Puppet::Face[:node_rackspace, :current] }
+
+  server_attributes = {
+    :id        => '12345678',
+    :name      => 'slice12345678',
+    :host_id   => '277eed7bbd0aaffdebe80a3b27183837',
+    :addresses => { "public" => '127.0.0.1' },
+    :state     => 'BUILD',
+    :progress  => '0',
+  }
+
+  describe 'option validation' do
+    context 'without any options' do
+      it 'should require server_id' do
+        pattern = /wrong number of arguments/
+        expect { subject.find }.to raise_error ArgumentError, pattern
+      end
+    end
+  end
+
+  describe 'the behavior of find' do
+    before :each do
+      Puppet::CloudPack::Rackspace.any_instance.stubs(:create_connection).returns(server)
+    end
+
+    context 'when a server exists' do
+      let(:server) do
+        mock('Fog::Compute[:rackspace]') do
+          expects(:servers).returns(self)
+          expects(:get).returns(self)
+          expects(:attributes).returns(server_attributes)
+        end
+      end
+
+      it 'should find a server' do
+         expected_attributes = {
+          :id        => '12345678',
+          :name      => 'slice12345678',
+          :host_id   => '277eed7bbd0aaffdebe80a3b27183837',
+          :addresses => { "public" => '127.0.0.1' },
+          :state     => 'BUILD',
+          :progress  => '0',
+        }
+        subject.find('123456789').should == [expected_attributes]
+      end
+    end
+
+    context 'when a server does not exists' do
+      let(:server) do
+        mock('Fog::Compute[:rackspace]') do
+          expects(:servers).returns(self)
+          expects(:get).returns(nil)
+          expects(:attributes).never
+        end
+      end
+
+      it 'should not find a server' do
+        subject.find('123456789').should == []
+      end
+    end
+  end
+
+  describe 'inline documentation' do
+    subject { Puppet::Face[:node_rackspace, :current].get_action :find }
+
+    its(:summary)     { should =~ /find.*rackspace/im }
+    its(:description) { should =~ /find.*rackspace/im }
+    its(:returns)     { should =~ /hash/i }
+    its(:examples)    { should_not be_empty }
+
+    %w{ license copyright summary description returns examples }.each do |doc|
+      context "of the" do
+        its(doc.to_sym) { should_not =~ /(FIXME|REVISIT|TODO)/ }
+      end
+    end
+  end
+end

--- a/spec/unit/puppet/face/node_rackspace/list_spec.rb
+++ b/spec/unit/puppet/face/node_rackspace/list_spec.rb
@@ -1,0 +1,136 @@
+require 'spec_helper'
+
+describe 'puppet node_rackspace list' do
+  subject { Puppet::Face[:node_rackspace, :current] }
+
+  describe 'option validation' do
+    context 'without any options' do
+      it 'should require kind' do
+        pattern = /wrong number of arguments/
+        expect { subject.list }.to raise_error ArgumentError, pattern
+      end
+    end
+  end
+
+  describe 'the behavior of list' do
+    before :each do
+      Puppet::CloudPack::Rackspace.any_instance.stubs(:create_connection).returns(model)
+    end
+
+    context 'when kind is images' do
+      images = {
+        :body => {
+          'images' => [
+            { 'name'    => 'Debian 6 (Squeeze)',
+              'id'      => 104,
+              'updated' => '2011-10-27T12:20:27-05:00',
+              'status'  => 'ACTIVE'
+            }
+          ]
+        }
+      }
+
+      let(:model) do
+        mock('Fog::Compute[:rackspace]') do
+          expects(:list_images_detail).returns(self)
+          expects(:attributes).returns(images)
+        end
+      end
+
+      let(:kind) { 'images' }
+
+      it 'should set kind to images' do
+        subject.list(kind)[:kind].should == 'images'
+      end
+
+      it 'should return a list of images' do
+        subject.list(kind)[:images].should be_a_kind_of(Array)
+      end
+
+      it 'should return a list of image attributes' do
+        subject.list(kind)[:images].should == images[:body]['images']
+      end
+    end
+
+    context 'when kind is servers' do
+      server_attributes = {
+        :id        => '12345678',
+        :name      => 'slice12345678',
+        :host_id   => '277eed7bbd0aaffdebe80a3b27183837',
+        :addresses => { "public" => '127.0.0.1' },
+        :state     => 'BUILD',
+        :progress  => '0',
+      }
+
+      let(:model) do
+        mock('Fog::Compute[:rackspace]') do
+          expects(:empty?).returns(false)
+          expects(:servers).returns(self)
+          expects(:collect).yields(self).returns([server_attributes])
+          expects(:attributes).returns(server_attributes)
+        end
+      end
+
+      let(:kind) { 'servers' }
+
+      it 'should set kind to servers' do
+        subject.list(kind)[:kind].should == 'servers'
+      end
+
+      it 'should return a list of servers' do
+        subject.list(kind)[:servers].should be_a_kind_of(Array)
+      end
+
+      it 'should return a list of servers attributes' do
+        subject.list(kind)[:servers].should == [server_attributes]
+      end
+    end
+
+    context 'when kind is flavors' do
+      flavors = {
+        :body => {
+          'flavors' => [
+            { 'name' => '256 server', 'id' => 1, 'ram' => 256, 'disk' => 10 },
+            { 'name' => '512 server', 'id' => 2, 'ram' => 512, 'disk' => 20 }
+          ]
+        }
+      }
+
+      let(:model) do
+        mock('Fog::Compute[:rackspace]') do
+          expects(:list_flavors_detail).returns(self)
+          expects(:attributes).returns(flavors)
+        end
+      end
+
+      let(:kind) { 'flavors' }
+
+      it 'should set kind to flavors' do
+        subject.list(kind)[:kind].should == 'flavors'
+      end
+
+      it 'should return a list of flavors' do
+        subject.list(kind)[:flavors].should be_a_kind_of(Array)
+      end
+
+      it 'should return a list of flavor attributes' do
+        subject.list(kind)[:flavors].should == flavors[:body]['flavors']
+      end
+    end
+  end
+
+  describe 'inline documentation' do
+    subject { Puppet::Face[:node_rackspace, :current].get_action :list }
+
+    its(:summary)     { should =~ /list.*rackspace/im }
+    its(:description) { should =~ /list.*rackspace/im }
+    its(:returns)     { should =~ /hash/i }
+    its(:examples)    { should_not be_empty }
+
+    %w{ license copyright summary description returns examples }.each do |doc|
+      context "of the" do
+        its(doc.to_sym) { should_not =~ /(FIXME|REVISIT|TODO)/ }
+      end
+    end
+  end
+end

--- a/spec/unit/puppet/face/node_rackspace/reboot_spec.rb
+++ b/spec/unit/puppet/face/node_rackspace/reboot_spec.rb
@@ -1,0 +1,67 @@
+require 'spec_helper'
+
+describe 'puppet node_rackspace reboot' do
+  subject { Puppet::Face[:node_rackspace, :current] }
+
+  describe 'option validation' do
+    context 'without any options' do
+      it 'should require serverid' do
+        pattern = /wrong number of arguments/
+        expect { subject.reboot }.to raise_error ArgumentError, pattern
+      end
+    end
+  end
+
+  describe 'the behavior of reboot' do
+    before :each do
+      Puppet::CloudPack::Rackspace.any_instance.stubs(:create_connection).returns(server)
+    end
+
+    context 'when a cloud server matches the serverid' do
+      let(:server) do
+        mock('Fog::Compute[:rackspace]') do
+          expects(:servers).returns(self)
+          expects(:get).returns(self)
+          expects(:reboot).once
+        end
+      end
+
+      it 'should accept a serverid' do
+        subject.reboot('12345678')
+      end
+
+      it 'should return a status hash' do
+        subject.reboot('12345678').should be_a_kind_of(Hash)
+      end
+    end
+
+    context 'when no cloud servers match the serverid' do
+      let(:server) do
+        mock('Fog::Compute[:rackspace]') do
+          expects(:servers).returns(self)
+          expects(:get).returns(nil)
+          expects(:reboot).never
+        end
+      end
+
+      it 'should not invoke reboot' do
+        subject.reboot('12345678')
+      end
+    end
+  end
+
+  describe 'inline documentation' do
+    subject { Puppet::Face[:node_rackspace, :current].get_action :reboot }
+
+    its(:summary)     { should =~ /reboot.*rackspace/im }
+    its(:description) { should =~ /reboot.*rackspace/im }
+    its(:returns)     { should =~ /hash/i }
+    its(:examples)    { should_not be_empty }
+
+    %w{ license copyright summary description returns examples }.each do |doc|
+      context "of the" do
+        its(doc.to_sym) { should_not =~ /(FIXME|REVISIT|TODO)/ }
+      end
+    end
+  end
+end

--- a/spec/unit/puppet/face/node_rackspace/terminate_spec.rb
+++ b/spec/unit/puppet/face/node_rackspace/terminate_spec.rb
@@ -1,0 +1,67 @@
+require 'spec_helper'
+
+describe 'puppet node_rackspace terminate' do
+  subject { Puppet::Face[:node_rackspace, :current] }
+
+  describe 'option validation' do
+    context 'without any options' do
+      it 'should require serverid' do
+        pattern = /wrong number of arguments/
+        expect { subject.terminate }.to raise_error ArgumentError, pattern
+      end
+    end
+  end
+
+  describe 'the behavior of terminate' do
+    before :each do
+      Puppet::CloudPack::Rackspace.any_instance.stubs(:create_connection).returns(servers)
+    end
+
+    context 'when a cloud server matches the serverid' do
+      let(:servers) do
+        mock('Fog::Compute[:rackspace]') do
+          expects(:servers).returns(self)
+          expects(:get).returns(self)
+          expects(:destroy).once
+        end
+      end
+
+      it 'should accept a serverid' do
+        subject.terminate('12345678')
+      end
+
+      it 'should return a status hash' do
+        subject.terminate('12345678').should be_a_kind_of(Hash)
+      end
+    end
+
+    context 'when no cloud servers match the serverid' do
+      let(:servers) do
+        mock('Fog::Compute[:rackspace]') do
+          expects(:servers).returns(self)
+          expects(:get).returns(nil)
+          expects(:destroy).never
+        end
+      end
+
+      it 'should not invoke destory' do
+        subject.terminate('12345678')
+      end
+    end
+  end
+
+  describe 'inline documentation' do
+    subject { Puppet::Face[:node_rackspace, :current].get_action :terminate }
+
+    its(:summary)     { should =~ /terminate.*rackspace/im }
+    its(:description) { should =~ /terminate.*rackspace/im }
+    its(:returns)     { should =~ /hash/i }
+    its(:examples)    { should_not be_empty }
+
+    %w{ license copyright summary description returns examples }.each do |doc|
+      context "of the" do
+        its(doc.to_sym) { should_not =~ /(FIXME|REVISIT|TODO)/ }
+      end
+    end
+  end
+end


### PR DESCRIPTION
This is a work in progress to add Rackspace Cloud Servers support to
cloudpack. Without this patch Cloud Provisioner does not support
Rackspace Cloud Servers.

This patch adds a new face command `node_rackspace` which provides the
following features:
- provision new Rackspace Cloud Servers
- reboot/terminate Rackspace Cloud Servers
- list Rackspace images, flavors, and servers

Detailed documentation can be found in docs/Rackspace.markdown

This patch also includes the related tests
