### PR TITLE
(#11015) Retry on failed auth for slow provisions

### DIFF
--- a/lib/puppet/cloudpack.rb
+++ b/lib/puppet/cloudpack.rb
@@ -770,7 +770,7 @@ module Puppet::CloudPack
           end
         end
       rescue Net::SSH::AuthenticationFailed => user
-        raise Puppet::Error, "Authentication failure for user #{user}. Please check the keyfile and try again."
+        raise Net::SSH::AuthenticationFailed, "Authentication failure for user #{user}. Please check the keyfile and try again."
       end
 
       Puppet.info "Executing remote command ... Done"


### PR DESCRIPTION
AWS sometimes brings up an instance before credentials have been seeded,
so node_aws should allow retries on failed authentication to avoid
prematurely erroring out.
