### PR TITLE
(#10971) Adding --facts options for install action

### DIFF
--- a/lib/puppet/cloudpack.rb
+++ b/lib/puppet/cloudpack.rb
@@ -186,6 +186,37 @@ module Puppet::CloudPack
     end
 
     def add_install_options(action)
+      action.option '--facts=' do
+        summary 'Set custom facts in format of fact1=value,fact2=value'
+        description <<-'EOT'
+          To install custom facts during install of a node, use the format
+          fact1=value,fact2=value. Currently, there is no way to escape 
+          the ',' character so facts cannot contain this character.
+
+          Requirements:
+          For community installs of puppet, i.e. not Puppet Enterprise,
+          the Puppet Labs' `stdlib` module will be required. It can be found
+          at 'http://forge.puppetlabs.com/puppetlabs/stdlib' or installed
+          with the command 'puppet-module install puppetlabs/stdlib'.
+
+          For Puppet Enterprise installs, there are no extra requirements
+          for this option to work
+        EOT
+
+        before_action do |action, arguments, options|
+          ## This converts 'this=that,foo=bar,biz=baz=also' to
+          ## { 'this' => 'that', 'foo' => 'barr', 'biz' => 'baz=also'}
+          ##
+          ## A regex is needed that will allow us to escape ',' characters
+          ## from the CLI
+          begin
+            options[:facts] = Hash[ options[:facts].split(',').map { |fact| fact.split('=',2) } ]
+          rescue
+            raise ArgumentError, 'Could not parse facts given. Please check your format'
+          end
+        end
+      end
+
       action.option '--login=', '-l=', '--username=' do
         summary 'User to login to the instance as.'
         description <<-EOT

--- a/lib/puppet/cloudpack/scripts/puppet-community.erb
+++ b/lib/puppet/cloudpack/scripts/puppet-community.erb
@@ -87,6 +87,21 @@ function start_puppet() {
   /etc/init.d/puppet start
 }
 
+#This fuction is not called if no custom facts are given
+#
+#The Puppet Labs' stdlib module is required for this to work
+#It can be installed using: 
+# 'puppet-module install puppetlabs/stdlib'
+function facts_dot_d() {
+  mkdir -p /etc/facter/facts.d
+  <% if options[:facts] %>
+  echo "Installing custom facts"
+  <% options[:facts].each do |fact,value| %>
+  echo <%= fact %>=<%= value %> > /etc/facter/facts.d/<%= fact %>.txt
+  <% end %>
+  <% end %>
+}
+
 function provision_puppet() {
   if [ -f /etc/redhat-release ]; then
     export breed='redhat'
@@ -99,6 +114,7 @@ function provision_puppet() {
   
   install_puppet
   configure_puppet
+  <%= 'facts_dot_d' if options[:facts] %>
   start_puppet
   echo "Puppet installation finished!"
   exit 0

--- a/lib/puppet/cloudpack/scripts/puppet-enterprise-http.erb
+++ b/lib/puppet/cloudpack/scripts/puppet-enterprise-http.erb
@@ -58,8 +58,17 @@ $http_get '<%= options[:installer_payload] %>' | \
 # REVISIT (This assumes GNU tar with the --strip-components option)
 echo "Uncompressing the payload ... Done."
 
-# Finally, actually install Puppet Enterprise
+# Install Puppet Enterprise
 "${install_dir}"/puppet-enterprise-installer -a puppet.answers 2>&1 | tee install.log
+
+# Finally, set up any custom facts if necessary
+mkdir -p /etc/puppetlabs/facter/facts.d
+<% if options[:facts] %>
+echo "Installing custom facts"
+<% options[:facts].each do |fact,value| %>
+echo <%= fact %>=<%= value %> > /etc/puppetlabs/facter/facts.d/<%= fact %>.txt
+<% end %>
+<% end %>
 
 # And then kick off a puppet agent run
 /opt/puppet/bin/puppet agent --daemonize \

--- a/lib/puppet/cloudpack/scripts/puppet-enterprise.erb
+++ b/lib/puppet/cloudpack/scripts/puppet-enterprise.erb
@@ -30,7 +30,16 @@ fi
 <% end %>
 
 
-# Finally, actually install Puppet Enterprise
+# Install Puppet Enterprise
 "${install_dir}"/puppet-enterprise-installer -a puppet.answers 2>&1 | tee install.log
+
+# Finally, set up any custom facts if necessary
+mkdir -p /etc/puppetlabs/facter/facts.d
+<% if options[:facts] %>
+echo "Installing custom facts"
+<% options[:facts].each do |fact,value| %>
+echo <%= fact %>=<%= value %> > /etc/puppetlabs/facter/facts.d/<%= fact %>.txt
+<% end %>
+<% end %>
 
 # vim:ft=sh

--- a/spec/unit/puppet/face/node/install_spec.rb
+++ b/spec/unit/puppet/face/node/install_spec.rb
@@ -11,7 +11,8 @@ describe Puppet::Face[:node, :current] do
       :login             => 'ubuntu',
       :keyfile           => @keyfile.path,
       :installer_payload => @installer_payload.path,
-      :installer_answers => @installer_answers.path
+      :installer_answers => @installer_answers.path,
+      :facts             => 'fact1=value1,fact2=value2,fact3=value3.1=value3.2'
     }
     ENV['SSH_AUTH_SOCK'] = '/tmp/foo.socket'
   end
@@ -48,6 +49,22 @@ describe Puppet::Face[:node, :current] do
       it 'should validate the keyfile name for readability' do
         File.chmod 0300, @options[:keyfile]
         expect { subject.install('server', @options) }.to raise_error ArgumentError, /could not read/i
+      end
+    end
+
+    describe '(facts)' do
+      let(:facts_hash) do { 'fact1' => 'value1', 'fact2' => 'value2', 'fact3' => 'value3.1=value3.2' }; end
+
+      it 'should produce a hash correctly' do
+        Puppet::CloudPack.expects(:install).with do |server,options|
+          options[:facts] == facts_hash
+        end
+        subject.install('server', @options)
+      end
+
+      it 'should exit on improper value' do
+        @options[:facts] = 'fact1=value1,fact2=val,ue2,fact3=value3.1=value3.2'
+        expect { subject.install('server', @options) }.to raise_error ArgumentError, /could not parse/i 
       end
     end
 


### PR DESCRIPTION
The --facts option installs custom facts using facter-dot-d. Each fact
gets its own .txt file in /etc/facts.d. On the command line, facts
are comma separated and are set using = character.  For example:
fact1=value,fact2=value makes two facts, 'fact1' and 'fact2' with
both having values of 'value'. Only the first '=' character is
matched so a fact set using fact=value=2 will result in a fact
called 'fact' with value 'value=2'.  Currently you can not escape
the ',' character.

The puppet-community, puppet-enterprise, and puppet-enterprise-http
install scripts have been modified to install the custom facts if
present. Since PE comes with the facter-dot-d plugin, it will
'just work,' however the module will have to be installed on
any community installs for the facts to be available to facter
