### PR TITLE
Request pseudo-tty when opening SSH connections

### DIFF
--- a/lib/puppet/cloudpack.rb
+++ b/lib/puppet/cloudpack.rb
@@ -764,6 +764,7 @@ module Puppet::CloudPack
       begin
         Net::SSH.start(server, login, ssh_opts) do |session|
           session.open_channel do |channel|
+            channel.request_pty
             channel.on_data do |ch, data|
               buffer << data
               stdout << data


### PR DESCRIPTION
Without a pseudo-tty, any commands executed with sudo fail with a tty error. See here in the Net::SSH documentation - 

http://net-ssh.github.com/ssh/v2/api/classes/Net/SSH/Connection/Channel.html#M000055

This simulates ssh -t. 
