### PR TITLE
(#10189) Add AWS availability zone option 

### DIFF
--- a/lib/puppet/cloudpack.rb
+++ b/lib/puppet/cloudpack.rb
@@ -19,7 +19,14 @@ module Puppet::CloudPack
       default_options = { :region => 'us-east-1', :platform => 'AWS', :install_script => 'gems' }
       default_options.merge(options)
     end
-
+    def add_availability_zone_option(action)
+      action.option '--availability-zone=' do
+        summary 'AWS availability zone.'
+        description <<-EOT
+          Specifies the availability zone into which the VM will be created
+        EOT
+     end
+    end
     def add_region_option(action)
       action.option '--region=' do
         summary "The geographic region of the instance. Defaults to us-east-1."
@@ -80,6 +87,7 @@ module Puppet::CloudPack
     def add_create_options(action)
       add_platform_option(action)
       add_region_option(action)
+      add_availability_zone_option(action)
 
       action.option '--image=', '-i=' do
         summary 'AMI to use when creating the instance.'
@@ -472,7 +480,8 @@ module Puppet::CloudPack
         :image_id   => options[:image],
         :key_name   => options[:keyname],
         :groups     => options[:group],
-        :flavor_id  => options[:type]
+        :flavor_id  => options[:type],
+        :availability_zone => options[:availability_zone]
       )
 
       # This is the earliest point we have knowledge of the instance ID

--- a/spec/unit/puppet/face/node_aws/create_spec.rb
+++ b/spec/unit/puppet/face/node_aws/create_spec.rb
@@ -78,6 +78,12 @@ describe Puppet::Face[:node_aws, :current] do
           /unrecognized.*: #{@options[:keyname]}/i
       end
     end
+    describe '(availability_zone)' do
+      it "should validate the availability zone" do
+        @options[:availability_zone] = 'test-puppet-zone'
+        expect { subject.create(@options) }.to raise_error ArgumentError, /Invalid availability zone/
+      end
+    end
 
     describe '(region)' do
       it "should set the region to us-east-1 if no region is supplied" do


### PR DESCRIPTION
Without this patch, Cloud Provisioner does not have the ability to create AWS
instances in a specific availability zone, only a region.  This patch adds the
ability to create instances in specific AWS availability zones within a region.
