### PR TITLE
Add the ability to create, attach and tag volumes

### DIFF
--- a/lib/puppet/face/node_aws/create_volume.rb
+++ b/lib/puppet/face/node_aws/create_volume.rb
@@ -1,0 +1,31 @@
+require 'puppet/cloudpack'
+require 'puppet/face/node_aws'
+
+Puppet::Face.define :node_aws, '0.0.1' do
+  action :create_volume do
+
+    summary 'Create a new EBS volume'
+
+    description <<-'EOT'
+      This action creates an EBS volume that is available to instances to mount.
+    EOT
+
+    Puppet::CloudPack.add_create_volume_options(self)
+
+    when_invoked do |options|
+      Puppet::CloudPack.create_volume(options)
+    end
+
+    when_rendering :console do |value|
+      value.to_s
+    end
+
+    returns "Volume ID of EBS volume created"
+
+    examples <<-'EOT'
+       $ puppet node_aws create_volume --size 10 [ --snapshot-id snap-7334e011 ]
+       vol-ccc507a1
+    EOT
+
+  end
+end


### PR DESCRIPTION
As commented in the commit note, I have merged this with a known working copy at Apigee. However, I have not tested this file specifically.

This adds the ability to create and attach EBS volumes to new instances. It also adds custom tags support, including for volumes. This is the pull request for cloud provisioner ticket 11301.
