### PR TITLE
(#11304) Add custom tag support

### DIFF
--- a/spec/unit/puppet/face/node_aws/create_spec.rb
+++ b/spec/unit/puppet/face/node_aws/create_spec.rb
@@ -15,6 +15,7 @@ describe Puppet::Face[:node_aws, :current] do
       :type     => 'm1.small',
       :keyname  => 'some_keypair',
       :region   => 'us-east-1',
+      :tags     => 'tag1=value1,tag2=value2'
     }
   end
 
@@ -38,6 +39,22 @@ describe Puppet::Face[:node_aws, :current] do
       it 'should validate the platform' do
         @options[:platform] = 'UnsupportedProvider'
         expect { subject.create(@options) }.to raise_error ArgumentError, /one of/
+      end
+    end
+
+    describe '(facts)' do
+      let (:tags_hash) do { 'tag1' => 'value1', 'tag2' => 'value2', 'tag3' => 'value3.1=value3.2' }; end
+
+      it 'should produce a hash correctly' do
+        Puppet::CloudPack.expects(:create).with do |options|
+          options[:tags] = tags_hash
+        end
+        subject.create(@options)
+      end
+
+      it 'should exit on improper value' do
+        @options[:tags] = 'tag1=value2,tag2=value,=broken'
+        expect { subject.create(@options) }.to raise_error ArgumentError, /could not parse/i
       end
     end
 


### PR DESCRIPTION
Previous to this commit, it was not possible for the
user to specify custom EC2 tags for instances.
The only tag generated had a key of 'Created by'
with a value of 'Puppet'.

Users commonly use tags to help identify and organize
instances within their organization. This commit
provides the capability for users to specify the tags
during the create action.

It does so by specifying a --tags option that takes a
value in the form of 'tag1=value,tag2=value'.
Currently the ',' cannot be escaped.  The create_tags
function has been rewritten to accept a third
parameters that is a hash of the tags to generate.

Spec tests to test the tags hash is being generated
correctly are included.
