### PR TITLE
(#11324 ) Properly validate tags and facts options

### DIFF
--- a/lib/puppet/cloudpack.rb
+++ b/lib/puppet/cloudpack.rb
@@ -122,6 +122,9 @@ module Puppet::CloudPack
               if tag_array.size != 2
                 raise ArgumentError, 'Could not parse tags given. Please check your format'
               end
+              if [nil,''].include? tag_array[0] or [nil,''].include? tag_array[1]
+                raise ArgumentError, 'Could not parse tags given. Please check your format'
+              end
               tag_array
             end ]
           rescue
@@ -266,6 +269,9 @@ module Puppet::CloudPack
             options[:facts] = Hash[ options[:facts].split(',').map do |fact| 
               fact_array = fact.split('=',2)
               if fact_array.size != 2
+                raise ArgumentError, 'Could not parse facts given. Please check your format'
+              end
+              if [nil,''].include? fact_array[0] or [nil,''].include? fact_array[1]
                 raise ArgumentError, 'Could not parse facts given. Please check your format'
               end
               fact_array


### PR DESCRIPTION
Previous to this commit, an improper
hash could have been generated if the user
input was invalid.  This commit tests
that for each tag and fact given,
the key and the value are not nil and
not empty.
