### PR TITLE
Fixes the use of Puppet.warn.

### DIFF
--- a/lib/puppet/cloudpack.rb
+++ b/lib/puppet/cloudpack.rb
@@ -831,7 +831,7 @@ module Puppet::CloudPack
       if results[:exit_code] == 0 then
         puppetagent_certname = results[:stdout].strip
       else
-        Puppet.warn "Could not determine the remote puppet agent certificate name using #{certname_command}"
+        Puppet.warning "Could not determine the remote puppet agent certificate name using #{certname_command}"
         puppetagent_certname = nil
       end
 


### PR DESCRIPTION
This patch converts the final use of Puppet.warn to Puppet.warning.
  Doesn't change any behavior but allows bootstrap action to complete in
  the event that a certname can't be obtained from configprint.  Without
  this the failure to obtain the certname will cause a backtrace.
  This had to be done because the warn method was changed to being a
  private method.
