### PR TITLE
(#11959) Use Puppet.warning instead of Puppet.warn

### DIFF
--- a/lib/puppet/cloudpack.rb
+++ b/lib/puppet/cloudpack.rb
@@ -831,7 +831,7 @@ module Puppet::CloudPack
       if results[:exit_code] == 0 then
         puppetagent_certname = results[:stdout].strip
       else
-        Puppet.warn "Could not determine the remote puppet agent certificate name using #{certname_command}"
+        Puppet.warning "Could not determine the remote puppet agent certificate name using #{certname_command}"
         puppetagent_certname = nil
       end
 


### PR DESCRIPTION
Previously, Puppet.warn was used in lib/puppet/cloudpack.rb if the
remote Puppet agent certname couldn't be determined. Now, Puppet.warning
will be used instead.
