### PR TITLE
(#12499) Watch for error states during instance creation

### DIFF
--- a/spec/unit/puppet/cloudpack_spec.rb
+++ b/spec/unit/puppet/cloudpack_spec.rb
@@ -117,6 +117,23 @@ describe Puppet::CloudPack do
             subject.should be_nil
           end
         end
+        describe 'like when the created instance is in an error state' do
+          before :each do
+            server do |server|
+              server.stubs(:state).returns('error')
+            end
+          end
+
+          it 'should explain what went wrong' do
+            subject
+            @logs.join.should match /Launching machine instance \S+ Failed/
+            @logs.join.should match /Instance has entered an error state/
+          end
+
+          it 'should return nil' do
+            subject.should be_nil
+          end
+        end
       end
     end
 


### PR DESCRIPTION
Previously, when creating a machine instance, the create action
would loop waiting for one of the following events:
- timeout
- Fog Exception
- created instance enters the state of 'running'

This does not correctly account for the fact that it is possible
for an openstack created machine instance to enter a state of 'error'

I frequently see error states when creating instance with the openstack
ec2 compatibility APIs. It usually occurs when there is either not
sufficient disk or memory to fullfill a request.

According to the ec2 docs, it appears that error is not a valid ec2 state:
  http://docs.amazonwebservices.com/AWSEC2/latest/APIReference/ApiReference-ItemType-InstanceStateType.html?r=1124
