### PR TITLE
(12717) Don't append to answers file if agent certname already present

### DIFF
--- a/lib/puppet/cloudpack.rb
+++ b/lib/puppet/cloudpack.rb
@@ -942,7 +942,7 @@ module Puppet::CloudPack
         end
       end
 
-      # Puppet enterprise install scripts, even those using S3, need and installer answer file.
+      # Puppet enterprise install scripts, even those using S3, need and installer answers file.
       if options[:install_script] =~ /^puppet-enterprise-/
         unless options[:installer_answers]
           raise "Must specify an answers file for install script #{options[:install_script]}"

--- a/lib/puppet/cloudpack/scripts/puppet-enterprise-http.erb
+++ b/lib/puppet/cloudpack/scripts/puppet-enterprise-http.erb
@@ -32,7 +32,7 @@ grep -v '^q_puppetagent_certname' puppet.answers.orig > puppet.answers
 # Append the user specified option from the command line arguments.
 echo 'q_puppetagent_certname=<%= options[:puppetagent_certname] %>' >> puppet.answers
 <% else %>
-#If we have a certname specified in the answer file, use it
+#If we have a certname specified in the answers file, use it
 if ! grep '^q_puppetagent_certname' puppet.answers; then
   echo 'q_puppetagent_certname=<%= options[:puppetagent_certname] %>' >> puppet.answers
 fi

--- a/lib/puppet/cloudpack/scripts/puppet-enterprise.erb
+++ b/lib/puppet/cloudpack/scripts/puppet-enterprise.erb
@@ -23,8 +23,8 @@ grep -v '^q_puppetagent_certname' puppet.answers.orig > puppet.answers
 # Append the user specified option from the command line arguments.
 echo 'q_puppetagent_certname=<%= options[:puppetagent_certname] %>' >> puppet.answers
 <% else %>
-#If we have a certname specified in the answer file, use it
-if ! grep '^q_puppetagent_certname' puppet.answer; then
+#If we have a certname specified in the answers file, use it
+if ! grep '^q_puppetagent_certname' puppet.answers; then
   echo 'q_puppetagent_certname=<%= options[:puppetagent_certname] %>' >> puppet.answers
 fi
 <% end %>

--- a/spec/unit/puppet/cloudpack_spec.rb
+++ b/spec/unit/puppet/cloudpack_spec.rb
@@ -548,7 +548,7 @@ describe Puppet::CloudPack do
           {}
         )
       end
-      it 'should upload answer file when specified' do
+      it 'should upload answers file when specified' do
         @scp_mock.expects(:upload).with('foo', "/tmp/puppet.answers")
         @result = subject.upload_payloads(
           @scp_mock,


### PR DESCRIPTION
Previously, if the `--puppetagent-certname` command line option was
not specified on the command line, then the `puppet-enterprise.erb`
template would always append a `q_puppetagent_certname` entry to the
answers file, regardless if one was already present. This was due to a
typo -- we were checking puppet.answer, but appending to
puppet.answers.
