### PR TITLE
Fix typos: "clasify" and "commmand"

### DIFF
--- a/lib/puppet/face/node/init.rb
+++ b/lib/puppet/face/node/init.rb
@@ -2,7 +2,7 @@ require 'puppet/cloudpack'
 
 Puppet::Face.define :node, '0.0.1' do
   action :init do
-    summary 'Install Puppet on a node and clasify it.'
+    summary 'Install Puppet on a node and classify it.'
     description <<-EOT
       Installs Puppet on an arbitrary node (see "install"), classify it in
       Puppet Dashboard or Puppet Enterprise's console (see "classify"), and

--- a/lib/puppet/face/node/install.rb
+++ b/lib/puppet/face/node/install.rb
@@ -6,7 +6,7 @@ Puppet::Face.define :node, '0.0.1' do
     description <<-EOT
       Installs Puppet on an existing node at <hostname_or_ip>. It uses scp to
       copy installation requirements to the machine, and ssh to run the
-      installation commmands remotely.
+      installation commands remotely.
 
       This action can be used on both physical and virtual machines.
     EOT


### PR DESCRIPTION
This commit fixes a pair of typos in the inline documentation for the node
subcommand.
