### PR TITLE
Provide puppet class to manage installation of CP

### DIFF
--- a/files/node_aws.rb
+++ b/files/node_aws.rb
@@ -1,0 +1,4 @@
+require 'puppet/application/face_base'
+
+class Puppet::Application::Node_aws < Puppet::Application::FaceBase
+end

--- a/lib/facter/puppet_install_dir.rb
+++ b/lib/facter/puppet_install_dir.rb
@@ -1,0 +1,7 @@
+require 'facter'
+
+Facter.add('puppet_install_dir') do
+  setcode do
+    $LOAD_PATH.find { |loc| File.exists? "#{loc}/puppet.rb" }
+  end
+end

--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -1,0 +1,46 @@
+# == Class: cloud_provisioner
+#
+# This class manages the installation of Cloud Provisioner on a node.
+# Particularly it installs the node_aws Face application into the appropriate
+# location on the system.
+#
+# === Parameters
+#
+# Document parameters here.
+#
+# [*puppet_installation_directory*]
+#   The directory of the puppet installation. It defaults to the value of the
+#   $puppet_install_dir Facter fact.
+# [*ensure*]
+#   The state of the node_aws sub application. Values can be
+#   ['present','absent','installed','uninstalled']. Defaults to 'present'
+#
+# === Examples
+#
+#  class { 'cloud_provisioner':
+#    ensure => present,
+#  }
+#
+# === Copyright
+#
+# Copyright 2011 Puppet Labs Inc
+#
+class cloud_provisioner(
+    $puppet_install_directory  = "${puppet_install_dir}/puppet",
+    $ensure = 'present'
+  ) {
+
+  case $ensure {
+    'present','installed':  { $ensure_safe = file   }
+    'absent','uninstalled': { $ensure_safe = absent }
+    default: {
+      fail "Unknown value ${ensure} of 'ensure' parameter for Class[cloud-provisioner].  Accepted values are ['present','absent']"
+    }
+  }
+
+  file { "${puppet_install_directory}/application/node_aws.rb":
+    ensure => $ensure_safe,
+    source => 'puppet:///modules/cloud_provisioner/node_aws.rb',
+    mode   => 0644,
+  }
+}


### PR DESCRIPTION
Previous to this commit, the installation of Cloud Provisioner required
a pluginsync to the agent as well as adding the $vardir to the $RUBYLIB
path. This was due to a long standing bug with Faces that requires any
Face that creates a new Puppet::Application child class to be manually
in the $RUBYLIB path.

This commit resolves this issue but providing a cloud_provisioner class
that installs the node_aws.rb file in the puppet/application directory.
The path to the application directory is determined by a Facter fact
this module also provides, $puppet_install_dir.  The class contains two
parameters:
- **$ensure** - Can be **present**, **absent**, **installed**, and
  **uninstalled**. Defaults to **present**
- $puppet_install_directory - Defaults to value of
  **$puppet_install_dir** fact

**NOTE**: This class is not necessary in Puppet 3.0+ as the Face
Puppet::Application bug has been fixed
