### PR TITLE
(#15450) Add terminate-id option to node_aws terminate

### DIFF
--- a/lib/puppet/face/node_aws/terminate.rb
+++ b/lib/puppet/face/node_aws/terminate.rb
@@ -5,8 +5,26 @@ Puppet::Face.define :node_aws, '0.0.1' do
   action :terminate do
     summary 'Terminate an EC2 machine instance.'
     description <<-EOT
-      Terminate the instance identified by <instance_name>.
+      Terminate the instance identified by its <terminate-id>.
+      The terminate-id flag is used to determine which EC2 identifier is
+      used for terminating instances.
     EOT
+
+    option '--terminate-id ID' do
+      summary 'field used to identify node to terminate'
+      description <<-EOT
+        Field used to identify the node to terminate. Can be set to
+        dns-name or instance-id.
+      EOT
+      default_to { 'dns-name' }
+
+      before_action do |action, args, options|
+        unless ['dns-name', 'instance-id' ].include?(options[:terminate_id])
+          raise(Puppet::Error, "Invalid terminate-id #{options[:terminate_id]}. Valid values are dns-name, instance-id")
+        end
+      end
+
+    end
 
     arguments '<instance_name>'
 

--- a/spec/unit/puppet/face/node_aws/terminate_spec.rb
+++ b/spec/unit/puppet/face/node_aws/terminate_spec.rb
@@ -27,6 +27,22 @@ describe Puppet::Face[:node_aws, :current] do
       end
     end
 
+    describe '(terminate-id)' do
+      ['dns-name', 'instance-id'].each do |id|
+        it "should accept valid id #{id}" do
+          options = {:terminate_id => id }
+          Puppet::CloudPack.expects(:terminate).with('server', options.merge({:region => 'us-east-1', :platform => 'AWS'}))
+          subject.terminate('server', options)
+        end
+      end
+      it 'should fail with unknown terminate ids' do
+        options = {:terminate_id => 'invalid' }
+        expect do
+          subject.terminate('server', options)
+        end.to raise_error(Puppet::Error, /Invalid terminate-id/)
+      end
+    end
+
     describe '(region)' do
       it "should set the region to us-east-1 if no region is supplied" do
         @options.delete(:region)


### PR DESCRIPTION
This commit adds the terminate-id option to the node_aws
terminate command.

This option allows users to select either dns-name (default)
or instance-id as the identifier to use for termination.

This option had previously been added to Puppet::Cloudpack
terminate method for use with the openstack cloud provisioner
plugin, but not exposed as an option to the face.
