### PR TITLE
Allow retry_action to accept a list of exceptions to retry as strings or symbols

### DIFF
--- a/lib/puppet/cloudpack/utils.rb
+++ b/lib/puppet/cloudpack/utils.rb
@@ -28,7 +28,9 @@ module Puppet::CloudPack::Utils
 
       retry_exceptions = parameters[:retry_exceptions].keys
 
-      if (not retry_exceptions.empty?) and (retry_exceptions.include?(e.class) or retry_exceptions.include?(e.class.to_s.to_sym))
+      if (not retry_exceptions.empty?) and (retry_exceptions.include?(e.class) \
+                                            or retry_exceptions.include?(e.class.to_s) \
+                                            or retry_exceptions.include?(e.class.to_s.to_sym))
         Puppet.info("Caught exception #{e.class}:#{e}")
         Puppet.info(parameters[:retry_exceptions][e.class])
       elsif (not retry_exceptions.empty?)

--- a/spec/unit/puppet/util_spec.rb
+++ b/spec/unit/puppet/util_spec.rb
@@ -80,6 +80,20 @@ describe Puppet::CloudPack::Utils do
           end
         end.to raise_error(Puppet::CloudPack::Utils::RetryException::Timeout)
       end
+
+      it "should accept a list of exception class names as strings" do
+        timeout = 2
+
+        exceptions = {
+          'ArgumentError' => 'Wrong number of arguments.'
+        }
+
+        expect do
+          Puppet::CloudPack::Utils.retry_action(:timeout => timeout, :retry_exceptions => exceptions) do
+            raise ArgumentError
+          end
+        end.to raise_error(Puppet::CloudPack::Utils::RetryException::Timeout)
+      end
     end
     
     context "when no arguments are given" do


### PR DESCRIPTION
Previous implementation only allowed the actual exception classes to be used.

Done as part of https://github.com/puppetlabs/puppetlabs-cloud-provisioner-vmware/pull/17 
