### PR TITLE
Patch for Issue #14943

### DIFF
--- a/spec/fog-stub-configuration
+++ b/spec/fog-stub-configuration
@@ -1,3 +1,6 @@
 :default:
   :aws_access_key_id: dummy
   :aws_secret_access_key: dummy
+  :endpoint: us-east-1.ec2.amazonaws.com
+  :region: us-east-1
+  :version: 2012-07-20


### PR DESCRIPTION
Patch submission for http://projects.puppetlabs.com/issues/14943.  

Added endpoint, version, and region to fog-stub-configuration to take advantage of fog's ability to work with different regions and API namespace version utilization with AWS.  This also allows for the fog AWS provider service to work with Eucalyptus (this was tested with Eucalyptus 3.1.1/3.1.2 versions).
