### PR TITLE
retry ssh when Errno::ENETUNREACH is encountered

### DIFF
--- a/lib/puppet/cloudpack.rb
+++ b/lib/puppet/cloudpack.rb
@@ -916,7 +916,8 @@ module Puppet::CloudPack
           Errno::ECONNREFUSED            => "Failed to connect. This may be because the machine is booting.  Retrying the connection...",
           Errno::ETIMEDOUT               => "Failed to connect. This may be because the machine is booting.  Retrying the connection..",
           Errno::ECONNRESET              => "Connection reset. Retrying the connection...",
-          Timeout::Error                 => "Connection test timed-out. This may be because the machine is booting.  Retrying the connection..."
+          Timeout::Error                 => "Connection test timed-out. This may be because the machine is booting.  Retrying the connection...",
+          Errno::ENETUNREACH             => "Network unreachable. Trying again to let routes stabilize."
       }
 
       Puppet::CloudPack::Utils.retry_action( :timeout => 250, :retry_exceptions => retry_exceptions ) do

--- a/spec/unit/puppet/cloudpack_spec.rb
+++ b/spec/unit/puppet/cloudpack_spec.rb
@@ -545,6 +545,12 @@ describe Puppet::CloudPack do
             expect { subject.ssh_test_connect('server', 'root', @keyfile.path) }.should raise_error(Puppet::CloudPack::Utils::RetryException::Timeout)
           end
         end
+        describe 'with Errno::ENETUNREACH' do
+          it 'should be tolerant of intermittent routing errors' do
+            Puppet::CloudPack.stubs(:ssh_remote_execute).raises(Errno::ENETUNREACH, 'root').then.returns(true)
+            subject.ssh_test_connect('server', 'root', @keyfile.path)
+          end
+        end
       end
       describe 'with general Exception failures' do
         it 'should not be tolerant of intermittent errors' do


### PR DESCRIPTION
This commit adds Errno::ENETUNREACH to the list of exceptions
that should result in a retry when encountered during ssh connections.

This exception can indicate that routing to an ip address has not
properly stabilized. I ran into this error when using source NAT
VPN with a cloudstack environment and I verified that the connection
was established if I retried a few times when this error was encountered.
