### PR TITLE
return stdout from executed scripts to install method

### DIFF
--- a/lib/puppet/cloudpack.rb
+++ b/lib/puppet/cloudpack.rb
@@ -834,6 +834,8 @@ module Puppet::CloudPack
         raise Puppet::Error, "The installation script exited with a non-zero exit status, indicating a failure.  It may help to run with --debug to see the script execution or to check the installation log file on the remote system in #{options[:tmp_dir]}."
       end
 
+      stdout = results[:stdout]
+
       # At this point we may assume installation of Puppet succeeded since the
       # install script returned with a zero exit code.
 
@@ -852,6 +854,7 @@ module Puppet::CloudPack
       {
         'status'               => 'success',
         'puppetagent_certname' => puppetagent_certname,
+        'stdout'               => stdout
       }
     end
 

--- a/spec/unit/puppet/cloudpack_spec.rb
+++ b/spec/unit/puppet/cloudpack_spec.rb
@@ -251,6 +251,9 @@ describe Puppet::CloudPack do
       it 'should return the specified certname' do
         subject.install(@server, @options)['status'].should == 'success'
       end
+      it 'should return stdout' do
+        subject.install(@server, @options)['stdout'].should == 'fakestdout'
+      end
       it 'should set server as public_dns_name option' do
         subject.expects(:compile_template).with do |options|
           options[:public_dns_name] == @server


### PR DESCRIPTION
I am expanding the usage of the install method to
do more things than just install puppet. For these purposes,
I need to see stdout from the ssh_remote_execute of the script.

This commit adds a key stdout to the returned hash.
