### PR TITLE
Support puppet_version for apt_install() function like RPM

### DIFF
--- a/lib/puppet/cloudpack/scripts/puppet-community.erb
+++ b/lib/puppet/cloudpack/scripts/puppet-community.erb
@@ -63,7 +63,7 @@ deb http://apt.puppetlabs.com/ ${release} main
 EOFAPTREPO
   apt-get update
   # Install Puppet from Debian repositories
-  apt-get -y install puppet
+  apt-get -y install puppet<% if options[:puppet_version] %>=<%= options[:puppet_version] %><% end %>
 }
 
 function install_puppet() {


### PR DESCRIPTION
rpm_install properly caters to puppet_version being set in the options, to install the requested version.

This was left out of the apt_install function.

I've added it.
