### PR TITLE
Fix for issue #18180: support --puppet-version in apt installs

### DIFF
--- a/lib/puppet/cloudpack/scripts/puppet-community.erb
+++ b/lib/puppet/cloudpack/scripts/puppet-community.erb
@@ -62,8 +62,16 @@ function apt_install() {
 deb http://apt.puppetlabs.com/ ${release} main
 EOFAPTREPO
   apt-get update
+  
+  # Get the latest Puppet revision from the repository
+  <% if options[:puppet_version] %>
+  export LATEST_PUPPET_VER=`apt-cache -n madison puppet | grep Packages | grep <%= options[:puppet_version] %> | head -1 | cut -d"|" -f2 | tr -d ' '`
+  <% end %>
+
   # Install Puppet from Debian repositories
-  apt-get -y install puppet
+  apt-get -y install puppet-common<% if options[:puppet_version] %>=$LATEST_PUPPET_VER<% end %>
+  apt-get -y install puppet<% if options[:puppet_version] %>=$LATEST_PUPPET_VER<% end %>
+
 }
 
 function install_puppet() {


### PR DESCRIPTION
In puppet-community.erb the `apt_install()` function doesn't use the puppet-version argument.

This commit fixes this, by using `apt-cache madison` to find the latest packages version from the apt repositories, and installs puppet-common prior to puppet to satisfy dependencies.

This fixes bug [#18180: --puppet-version does not work](http://projects.puppetlabs.com/issues/18180)
