### PR TITLE
Update CLI options to Fog key mappings

### DIFF
--- a/lib/puppet/cloudpack.rb
+++ b/lib/puppet/cloudpack.rb
@@ -123,7 +123,7 @@ module Puppet::CloudPack
           ## A regex is needed that will allow us to escape ',' characters
           ## from the CLI
           begin
-            options[:tags] = Hash[ options[:tags].split(',').map do |tag| 
+            options[:instance_tags] = Hash[ options[:instance_tags].split(',').map do |tag| 
               tag_array = tag.split('=',2)
               if tag_array.size != 2
                 raise ArgumentError, 'Could not parse tags given. Please check your format'
@@ -633,7 +633,7 @@ module Puppet::CloudPack
       server     = create_server(connection.servers,
         :image_id   => options[:image],
         :key_name   => options[:keyname],
-        :groups     => options[:group],
+        :groups     => options[:security_group],
         :flavor_id  => options[:type],
         :subnet_id     => options[:subnet],
         :availability_zone => options[:availability_zone]
@@ -651,7 +651,7 @@ module Puppet::CloudPack
 
       unless (options[:tags_not_supported])
         tags = {'Created-By' => 'Puppet'}
-        tags.merge! options[:tags] if options[:tags]
+        tags.merge! options[:instance_tags] if options[:instance_tags]
 
         Puppet.notice('Creating tags for instance ... ')
         create_tags(connection.tags, server.id, tags)


### PR DESCRIPTION
Recent updates to the options names in 24f86efeb5f9781d0c7c3d531698e765bd13697b failed to make the corresponding changes when mapping option names are passed to Fog.  This broke setting the security group(s) and tags on created instances.
