### PR TITLE
Amazon Linux not supported as bootstrap target

### DIFF
--- a/lib/puppet/cloudpack/scripts/puppet-community.erb
+++ b/lib/puppet/cloudpack/scripts/puppet-community.erb
@@ -128,6 +128,8 @@ function provision_puppet() {
     export breed='redhat'
   elif [ -f /etc/debian_version ]; then
     export breed='debian'
+  elif [ -f /etc/system-release ]; then
+    export breed='redhat'
   else
     echo "This OS is not supported by Puppet Cloud Provisioner"
     exit 1


### PR DESCRIPTION
Fix for http://projects.puppetlabs.com/issues/16608

When trying to bootstrap a Amazon Linux AMI I got the error:

debug: This OS is not supported by Puppet Cloud Provisioner

Amazon Linux runs CentOS and is rhel compatible.
