### PR TITLE
Solved a bug with tags handling

### DIFF
--- a/lib/puppet/cloudpack.rb
+++ b/lib/puppet/cloudpack.rb
@@ -633,7 +633,7 @@ module Puppet::CloudPack
       server     = create_server(connection.servers,
         :image_id   => options[:image],
         :key_name   => options[:keyname],
-        :groups     => options[:group],
+        :groups     => options[:security_group],
         :flavor_id  => options[:type],
         :subnet_id     => options[:subnet],
         :availability_zone => options[:availability_zone]


### PR DESCRIPTION
To avoid name clashing with puppet command --tags was changed to --instance-tags but the code didn't reflect this.
