### PR TITLE
PE-239: Cloud Provisioner has unused, obsolete `--pe-version` option

### DIFF
--- a/lib/puppet/cloudpack.rb
+++ b/lib/puppet/cloudpack.rb
@@ -430,19 +430,6 @@ module Puppet::CloudPack
         end
       end
 
-      action.option '--pe-version=' do
-        summary 'Version of Puppet Enterprise to install.'
-        description <<-EOT
-          Version of Puppet Enterprise to be passed to the installer script.
-          Defaults to 1.1.
-        EOT
-        before_action do |action, arguments, options|
-          unless options[:pe_version] =~ /^(\d+)\.(\d+)(\.(\d+))?$|^(\d)+\.(\d)+\.(\d+)([a-zA-Z][a-zA-Z0-9-]*)$/
-            raise ArgumentError, "Invaid Puppet Enterprise version '#{options[:pe_version]}'"
-          end
-        end
-      end
-
       action.option '--facter-version=' do
         summary 'Version of facter to install.'
         description <<-EOT


### PR DESCRIPTION
The Cloud Provisioner tools added an option to the command, `--pe-version`,
that claimed it determined what version of PE was installed.  In practice,
though, it was unused - nothing in the rest of the codebase consulted it.

This eliminates the option which, while very attractive, is now implemented by
picking the correct installation tarball or script source.

Signed-off-by: Daniel Pittman daniel@rimspace.net
