### PR TITLE
PE-247: SSL for ENC communication is now on, and mandatory

### DIFF
--- a/lib/puppet/cloudpack.rb
+++ b/lib/puppet/cloudpack.rb
@@ -459,16 +459,6 @@ module Puppet::CloudPack
     end
 
     def add_classify_options(action)
-      action.option '--enc-ssl' do
-        summary 'Whether to use SSL when connecting to the ENC.'
-        description <<-'EOT'
-          By default, we do not connect to the ENC over SSL.  This option
-          configures all HTTP connections to the ENC to use SSL in order to
-          provide encryption. This option should be set when using Puppet
-          Enterprise 2.0 and higher.
-        EOT
-      end
-
       action.option '--enc-server=' do
         summary 'The external node classifier hostname.'
         description <<-EOT
@@ -550,15 +540,10 @@ module Puppet::CloudPack
       # The Net::HTTP client instance
       http = Puppet::Network::HttpPool.http_instance(options[:enc_server], options[:enc_port])
 
-      if options[:enc_ssl] then
-        http.use_ssl = true
-        uri_scheme = 'https'
-        # We intentionally use SSL only for encryption and not authenticity checking
-        http.verify_mode = OpenSSL::SSL::VERIFY_NONE
-      else
-        http.use_ssl = false
-        uri_scheme = 'http'
-      end
+      http.use_ssl = true
+      uri_scheme = 'https'
+      # We intentionally use SSL only for encryption and not authenticity checking
+      http.verify_mode = OpenSSL::SSL::VERIFY_NONE
 
       Puppet.notice "Contacting #{uri_scheme}://#{options[:enc_server]}:#{options[:enc_port]}/ to classify #{certname}"
 

--- a/lib/puppet/face/node/classify.rb
+++ b/lib/puppet/face/node/classify.rb
@@ -22,7 +22,6 @@ Puppet::Face.define :node, '0.0.1' do
           puppet node classify \
             --enc-server puppetmaster.example.com \
             --enc-port 3000 \
-            --enc-ssl \
             --node-group pe_agents \
             agent01.example.com
     EOEXAMPLE

--- a/spec/unit/puppet/cloudpack_spec.rb
+++ b/spec/unit/puppet/cloudpack_spec.rb
@@ -336,7 +336,8 @@ describe Puppet::CloudPack do
     describe '#dashboard_classify' do
       before :each do
         @http = mock('Net::Http')
-        @http.expects('use_ssl=').with(false)
+        @http.expects('use_ssl=').with(true)
+        @http.expects('verify_mode=').with(0)
         @headers = { 'Content-Type' => 'application/json' }
       end
       def http_response_mock(stubbed_methods = {})

--- a/spec/unit/puppet/face/node/classify_spec.rb
+++ b/spec/unit/puppet/face/node/classify_spec.rb
@@ -28,13 +28,6 @@ describe Puppet::Face[:node, :current] do
         Puppet::CloudPack.expects(:dashboard_classify).with('server', expected_options).once
         subject.classify('server', options)
       end
-
-      it 'should accept the --enc-ssl option' do
-        options[:enc_ssl] = true
-        expected_options.merge!(options)
-        Puppet::CloudPack.expects(:dashboard_classify).with('agent_cn', expected_options).once
-        subject.classify('agent_cn', options)
-      end
     end
   end
 end


### PR DESCRIPTION
Earlier versions of Cloud Provisioner had an option to enable SSL for
communication with the ENC.  This was, by default, off - and included a
recommendation that any time in the last year it should be manually enabled by
the user.

This changes that: not only defaulting to turning on SSL, but making it
mandatory for all ENC communication.

Signed-off-by: Daniel Pittman daniel@rimspace.net
