### PR TITLE
PE-242: remove obsolete local AWS type validation

### DIFF
--- a/lib/puppet/cloudpack.rb
+++ b/lib/puppet/cloudpack.rb
@@ -165,16 +165,11 @@ module Puppet::CloudPack
           Type of instance to be launched. The type specifies characteristics that
           a machine will have, such as architecture, memory, processing power, storage,
           and IO performance. The type selected will determine the cost of a machine instance.
-          Supported types are: 'm1.small','m1.medium','m1.large','m1.xlarge','t1.micro','m2.xlarge',
-          'm2.2xlarge','x2.4xlarge','c1.medium','c1.xlarge','cc1.4xlarge'.
+
+          All instance types available from EC2 are supported; see the EC2 documentation
+          online at http://aws.amazon.com/ec2/instance-types/ for details.
         EOT
         required
-        before_action do |action, args, options|
-          supported_types = ['m1.small','m1.medium','m1.large','m1.xlarge','t1.micro','m2.xlarge','m2.2xlarge','x2.4xlarge','c1.medium','c1.xlarge','cc1.4xlarge']
-          unless supported_types.include?(options[:type])
-            raise ArgumentError, "Type must be one of the following: #{supported_types.join(', ')}"
-          end
-        end
       end
     end
 

--- a/spec/unit/puppet/face/node_aws/create_spec.rb
+++ b/spec/unit/puppet/face/node_aws/create_spec.rb
@@ -62,11 +62,6 @@ describe Puppet::Face[:node_aws, :current] do
         @options.delete(:type)
         expect { subject.create(@options) }.to raise_error ArgumentError, /required/
       end
-
-      it 'should validate the type' do
-        @options[:type] = 'UnsupportedType'
-        expect { subject.create(@options) }.to raise_error ArgumentError, /one of/
-      end
     end
 
     describe '(image)' do


### PR DESCRIPTION
The original AWS provisioning code was careful to validate the set of approved
EC2 instance types locally.  This was great, except that it wasn't kept up
to date.

A better strategy is to simply delegate this to the server: while it takes
longer to give the user an error message, EC2 is clear and effective in
communicating what went wrong, and we can't get much more authoritative than
the upstream service when it comes to actual validation.

Since we don't own changes to this data, and we can't upgrade the valid set in
the field, this seems like the better approach when trading off speed of error
reporting against ability to respond to change in third party systems.

Signed-off-by: Daniel Pittman daniel@rimspace.net
