### PR TITLE
PE-243: update copyright years in Cloud Provisioner

### DIFF
--- a/LICENSE
+++ b/LICENSE
@@ -186,7 +186,7 @@
       same "printed page" as the copyright notice for easier
       identification within third-party archives.
 
-   Copyright 2011 Puppet Labs
+   Copyright 2011-2013 Puppet Labs
 
    Licensed under the Apache License, Version 2.0 (the "License");
    you may not use this file except in compliance with the License.

--- a/lib/puppet/face/node_aws.rb
+++ b/lib/puppet/face/node_aws.rb
@@ -1,7 +1,7 @@
 require 'puppet/face'
 
 Puppet::Face.define(:node_aws, '0.0.1') do
-  copyright "Puppet Labs", 2011
+  copyright "Puppet Labs", 2011 .. 2013
   license   "Apache 2 license; see COPYING"
 
   summary "View and manage Amazon AWS EC2 nodes."


### PR DESCRIPTION
This updates the copyright dates to reflect copyright-relevant changes in both
2012 and 2013 made in this project.  No functional change.

Signed-off-by: Daniel Pittman daniel@rimspace.net
