### PR TITLE
Config both 'main' and 'dependencies' apt repos

### DIFF
--- a/lib/puppet/cloudpack/scripts/puppet-community.erb
+++ b/lib/puppet/cloudpack/scripts/puppet-community.erb
@@ -59,7 +59,7 @@ function apt_install() {
 
   # Setup the apt Puppet repository
   cat > /etc/apt/sources.list.d/puppetlabs.list <<EOFAPTREPO
-deb http://apt.puppetlabs.com/ ${release} main
+deb http://apt.puppetlabs.com/ ${release} main dependencies
 EOFAPTREPO
   apt-get update
   # Install Puppet from Debian repositories


### PR DESCRIPTION
Previously the apt installation setup only configured the
'main' repository. With Puppet 3.2's hard dependency on
the ruby-rgen module, this causes installation to fail due
to unmet dependencies.

This patch updates the script to configure both the 'main' and
'dependencies' repos so that `puppet node install` will work
on debian-based systems installing Puppet 3.2
