### PR TITLE
PE-1504: drop ruby 1.8.7 and add ruby 2.0.0 to the projects's travis-ci matrix

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -3,19 +3,13 @@ bundler_args: --without development
 script: "bundle exec rake spec SPEC_OPTS='--format documentation'"
 rvm:
   - 1.9.3
-  - 1.8.7
+  - 2.0.0
   - ruby-head
 env:
-  - PUPPET_GEM_VERSION="~> 2.7"
   - PUPPET_GEM_VERSION=">= 3.0.0"
 matrix:
   allow_failures:
     - rvm: ruby-head
-  exclude:
-    - rvm: 1.9.3
-      env: PUPPET_GEM_VERSION="~> 2.7"
-    - rvm: ruby-head
-      env: PUPPET_GEM_VERSION="~> 2.7"
 notifications:
   email: false
   webhooks:


### PR DESCRIPTION
This patch updates the project's travis-ci matrix as stated in the title to make the tests more useful. (As the tests didn't run with ruby 1.8.7 because the prerequisite `nokogiri` gem requires ruby version >= 1.9.2 and ruby 2.0.0 was not covered at all.)
