### PR TITLE
Support `google_compute_engine` ssh key by default

### DIFF
--- a/lib/puppet/cloudpack/gce.rb
+++ b/lib/puppet/cloudpack/gce.rb
@@ -86,7 +86,13 @@ module Puppet::CloudPack::GCE
         public key is stored.  The private key never leaves your machine.
       EOT
 
-      default_to { 'id_rsa' }
+      default_to do
+        if File.exist?('~/.ssh/google_compute_engine')
+          '~/.ssh/google_compute_engine'
+        else
+          'id_rsa'
+        end
+      end
 
       before_action do |action, args, options|
         # First, make sure the pathname is absolute; this turns relative names


### PR DESCRIPTION
The upstream gcutils tools default to the `google_compute_engine` ssh key;
this adapts our code to look for that first, and default to it if present.

If it does not exist we fall back to the normal `id_rsa` SSH credentials,
which follows the common practice of the rest of Cloud Provisioner.

Signed-off-by: Daniel Pittman daniel@rimspace.net
