### PR TITLE
Expand tildes in key path before testing for existence

### DIFF
--- a/lib/puppet/cloudpack/gce.rb
+++ b/lib/puppet/cloudpack/gce.rb
@@ -87,8 +87,8 @@ module Puppet::CloudPack::GCE
       EOT
 
       default_to do
-        if File.exist?('~/.ssh/google_compute_engine')
-          '~/.ssh/google_compute_engine'
+        if Pathname('google_compute_engine').expand_path('~/.ssh').exist?
+          'google_compute_engine'
         else
           'id_rsa'
         end


### PR DESCRIPTION
Unfortunately, while Ruby will implicitly expand a tilde in a file path in
most places, it doesn't actually do that for file existence tests.

This manually expands the path before performing the test, which makes the key
default detection actually work as expected.

Signed-off-by: Daniel Pittman daniel@rimspace.net
