### PR TITLE
Make `zone` argument optional for listing GCE instances

### DIFF
--- a/lib/puppet/cloudpack/gce.rb
+++ b/lib/puppet/cloudpack/gce.rb
@@ -21,10 +21,10 @@ module Puppet::CloudPack::GCE
     end
   end
 
-  def add_zone(to)
+  def add_zone(to, with_default = true)
     to.option '--zone us-central1-a' do
       summary 'Limit to instances in the specified zone'
-      default_to { 'us-central1-a' }
+      with_default and default_to { 'us-central1-a' }
     end
   end
 

--- a/lib/puppet/face/node_gce.rb
+++ b/lib/puppet/face/node_gce.rb
@@ -56,7 +56,10 @@ Puppet::Face.define(:node_gce, '1.0.0') do
       This provides a list of GCE compute instances for the selected project.
     EOT
 
-    Puppet::CloudPack::GCE.options(self, :project, :zone)
+    Puppet::CloudPack::GCE.options(self, :project)
+    # We can't have a default value for zone here, unlike every other
+    # operation that wants one.
+    Puppet::CloudPack::GCE.add_zone(self, false)
 
     when_invoked do |options|
       require 'puppet/google_api'


### PR DESCRIPTION
The GCE list operation can provide a per-zone list, or an aggregate list.
The later shows all nodes -- and was broken by earlier changes that unified
adding options to things, by setting a default value for zone on the
list action.

This fixes that, by extending the API for adding options to support an
optional default value for zone.

Signed-off-by: Daniel Pittman daniel@rimspace.net
