### PR TITLE
PE-2352: update puppet node_gce to use GCE v1 API

### DIFF
--- a/lib/puppet/face/node_gce.rb
+++ b/lib/puppet/face/node_gce.rb
@@ -32,8 +32,8 @@ Puppet::Face.define(:node_gce, '1.0.0') do
     when_invoked do |client_id, client_secret, options|
       require 'puppet/google_api'
 
-      Puppet::GoogleAPI.new(client_id, client_secret).discover('compute', 'v1beta15') or
-        raise "unable to discover the GCE v1beta15 API"
+      Puppet::GoogleAPI.new(client_id, client_secret).discover('compute', 'v1') or
+        raise "unable to discover the GCE v1 API"
 
       true
     end
@@ -277,6 +277,12 @@ Puppet::Face.define(:node_gce, '1.0.0') do
         flatten.
         select {|config| config.nat_ip }.
         first.nat_ip
+
+      # Look for the private key at the same place where the public key is
+      if !options.include?(:keyfile) && options.include?(:key)
+        options[:keyfile] = options[:key]
+        options[:keyfile].slice!(-4, 4) if options[:keyfile].end_with?('.pub')
+      end
 
       # Next, install Puppet on the machine.
       Puppet::CloudPack.init(host, options)

--- a/lib/puppet/google_api.rb
+++ b/lib/puppet/google_api.rb
@@ -12,10 +12,6 @@ class Puppet::GoogleAPI
   # the Google supplied images live in these.
   StandardImageProjects  = ['debian-cloud', 'centos-cloud']
 
-  # The list of "standard" projects to search for kernels when hunting by
-  # name; the Google supplied kernels live in these.
-  StandardKernelProjects = ['google']
-
   # Create a new instance; this will implicitly authorize if required, or
   # otherwise refresh the access token.  It makes state changes in the rest of
   # the system -- potentially storing the refresh token in the statedir, or

--- a/spec/template_helper.rb
+++ b/spec/template_helper.rb
@@ -1,0 +1,22 @@
+require 'tempfile'
+require 'fileutils'
+require 'puppet'
+
+def with_mock_user_template(content = 'Here is a <%= options[:variable] %>', name='foo', scripts_dir_name='scripts')
+  tmp_scripts_dir = File.join(Dir.tmpdir, scripts_dir_name)
+  FileUtils.mkdir(tmp_scripts_dir) unless File.exists?(tmp_scripts_dir)
+
+  template_tempfile = Tempfile.open([name, '.erb'], tmp_scripts_dir)
+
+  begin
+    template_tempfile.write(content)
+    template_tempfile.close
+    Puppet[:confdir] = File.dirname(tmp_scripts_dir)
+
+    yield File.basename(template_tempfile.path, '.erb')
+  ensure
+    # cleanup
+    template_tempfile.unlink
+    FileUtils.rmdir(tmp_scripts_dir)
+  end
+end

--- a/spec/unit/puppet/cloudpack/installer_spec.rb
+++ b/spec/unit/puppet/cloudpack/installer_spec.rb
@@ -1,46 +1,30 @@
-require 'tempfile'
-require 'fileutils'
+require 'spec_helper'
+require 'template_helper'
 require 'puppet'
 require 'puppet/cloudpack'
 require 'puppet/cloudpack/installer'
-require 'mocha'
-require 'spec_helper'
-installer_klass = Puppet::CloudPack::Installer
-script_dir_name='scripts'
-scripts_dir=File.expand_path("#{File.dirname(__FILE__)}/../../../../lib/puppet/cloudpack/#{script_dir_name}")
-describe installer_klass do
-  def tmp_template(content = 'Here is a <%= options[:variable] %>',name='foo', script_dir_name='scripts')
-    tmp_file = Tempfile.new(name).path
-    tmp_filename = File.basename(tmp_file)
-    tmp_basedir = File.join(File.dirname(tmp_file), script_dir_name)
-    FileUtils.mkdir(tmp_basedir) unless File.exists?(tmp_basedir)
-    tmp_file_real = File.join(tmp_basedir, "#{tmp_filename}.erb")
-    FileUtils.mv(tmp_file, tmp_file_real)
-    File.open(tmp_file_real, 'w') do |fh|
-      fh.write content
-    end
-    Puppet[:confdir] = File.dirname(tmp_file)
-    tmp_file_real
-  end
+
+describe Puppet::CloudPack::Installer do
   describe 'when searching for file location' do
-    it 'should override the system script with a users script' do
-      template_location = tmp_template
-      template_id = File.basename(template_location).gsub(/\.erb$/, '')
-      installer_klass.find_template(template_id).should == template_location
+    it 'should override the system script with a user script' do
+      with_mock_user_template do |template_id|
+        subject.find_template(template_id).should == File.join(Puppet[:confdir], 'scripts', template_id + '.erb')
+      end
     end
     it 'should be able to use a lib version' do
-      File.expand_path(installer_klass.find_template('puppet-enterprise')).should == File.join(scripts_dir, 'puppet-enterprise.erb')
+      subject.find_template('puppet-enterprise').should == File.join(subject.lib_script_dir, 'puppet-enterprise.erb')
     end
     it 'should fail when it cannot find a script' do
       now = Time.now.to_i
-      expect { installer_klass.find_template("foo_#{now}") }.to raise_error(Exception, /Could not find/)
+      expect { subject.find_template("foo_#{now}") }.to raise_error(Exception, /Could not find/)
     end
   end
+
   describe 'when compiling the script' do
     it 'should be able to compile erb templates' do
-      template_location = tmp_template
-      template_id = File.basename(template_location).gsub(/\.erb$/, '')
-      Puppet::CloudPack::Installer.build_installer_template(template_id, {:variable => 'bar'}).should == 'Here is a bar'
+      with_mock_user_template do |template_id|
+        subject.build_installer_template(template_id, {:variable => 'bar'}).should == 'Here is a bar'
+      end
     end
   end
 end


### PR DESCRIPTION
This patch updates `puppet node_gce` command to use the latest version of the GCE API - v1.

The v1 of the API deprecates kernel images and scratch boot disks. To compensate for that newly each GCE VM instance needs to have a permanent boot disk configured which must contain a kernel and a booloader capable of booting the kernel in much the same way as on a real hardware.

To keep up with the changes the `pupet node_gce create` command now creates a persistent disk out of the image specified with the `--image` option which is then used as the boot disk for the newly created instance.
Conversely when an instance is being deleted using the `puppet node_gce delete` command a check is made to see if it has a persistent boot disk configured and if it has then the disk is deleted along with the instance.
